### PR TITLE
Add eval2 package with NbE-based evaluator, quoter, and semantic domain

### DIFF
--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -1,0 +1,34 @@
+# NbE Migration - Shared Task Notes
+
+## Current State: Phase 1 Complete
+
+Phase 1 (eval2 in isolation) is implemented and tested. The migration plan is in `docs/nbe-migration-plan.md`.
+
+## What was done
+
+- Created `eval2/fact/` package: `Sem`, `Head`, `Closure`, `Env`, `MetaId`
+- Created `eval2/util/` package: `MetaState` (inProgress set only), `Evaluator2`, `Quoter`
+- 22 passing Evaluator2 tests, 10 passing Quoter tests
+
+## Next: Phase 2 - Metavariables and Unifier
+
+Per the plan (§6 Phase 2):
+1. Extend `MetaState` with meta operations: `freshMeta`, `solveMeta`, `lookupMeta`, `force`
+2. Implement `Unifier.unify` with pattern unification for meta-vs-other case
+3. Unit tests: `Lit == Lit`, `Struct == Struct`, `Lam == Lam`, `?m == concrete`, pattern unification, occurs check
+
+Key design decisions:
+- `MetaState` currently only has `inProgress: Set[ValueFQN]`. Needs `metas: Map[MetaId, MetaInfo]` and `nextId: Int`
+- `force(s: Sem)` chases meta solutions - implement in MetaState or as standalone util
+- `EvalIO[A] = StateT[CompilerIO, MetaState, A]` is already the right monad stack
+
+## Pre-existing test failures (not ours)
+
+- monomorphize2 tests: 28 failures (pre-existing, see memory note)
+- Old EvaluatorTest: 2 failures (pre-existing, commented-out code in Evaluator.scala)
+
+## File locations
+
+- Source: `lang/src/com/vanillasource/eliot/eliotc/eval2/{fact,util}/`
+- Tests: `lang/test/src/com/vanillasource/eliot/eliotc/eval2/util/`
+- Plan: `docs/nbe-migration-plan.md`

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Closure.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Closure.scala
@@ -1,0 +1,8 @@
+package com.vanillasource.eliot.eliotc.eval2.fact
+
+import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedExpression
+
+/** A closure capturing an environment and an unevaluated body. The body is re-evaluated
+  * when the closure is applied.
+  */
+case class Closure(env: Env, body: OperatorResolvedExpression)

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Env.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Env.scala
@@ -1,0 +1,10 @@
+package com.vanillasource.eliot.eliotc.eval2.fact
+
+/** An evaluation environment mapping parameter names to their semantic values. */
+case class Env(params: Map[String, Sem]) {
+  def extend(name: String, sem: Sem): Env = copy(params = params + (name -> sem))
+}
+
+object Env {
+  def empty: Env = Env(Map.empty)
+}

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Head.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Head.scala
@@ -1,0 +1,26 @@
+package com.vanillasource.eliot.eliotc.eval2.fact
+
+import cats.Show
+import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.module.fact.ValueFQN
+
+/** The head of a neutral term. Determines what kind of stuck computation this is. */
+sealed trait Head
+
+object Head {
+
+  /** A bound parameter that escaped its binder (free in the current scope). */
+  case class Param(name: String) extends Head
+
+  /** A unification metavariable. */
+  case class Meta(id: MetaId) extends Head
+
+  /** A top-level value reference whose body is blocked from reducing. */
+  case class Ref(vfqn: ValueFQN) extends Head
+
+  given Show[Head] = {
+    case Param(name) => name
+    case Meta(id)    => s"?${id.value}"
+    case Ref(vfqn)   => vfqn.show
+  }
+}

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/MetaId.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/MetaId.scala
@@ -1,0 +1,14 @@
+package com.vanillasource.eliot.eliotc.eval2.fact
+
+import cats.Eq
+
+/** An opaque identifier for unification metavariables. */
+opaque type MetaId = Int
+
+object MetaId {
+  def apply(id: Int): MetaId = id
+
+  extension (id: MetaId) def value: Int = id
+
+  given Eq[MetaId] = Eq.fromUniversalEquals
+}

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Sem.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/fact/Sem.scala
@@ -1,0 +1,41 @@
+package com.vanillasource.eliot.eliotc.eval2.fact
+
+import cats.Show
+import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.eval.fact.Value
+import com.vanillasource.eliot.eliotc.module.fact.ValueFQN
+
+/** The semantic domain for NbE-based evaluation. Represents values in normal form,
+  * with metavariables as first-class neutral heads.
+  */
+sealed trait Sem
+
+object Sem {
+
+  /** A literal value: BigInt, String, etc. */
+  case class Lit(direct: Value.Direct) extends Sem
+
+  /** The universe of types. */
+  case object TypeUniv extends Sem
+
+  /** A fully-evaluated structure (data type instance, function type, etc). */
+  case class Struct(typeFqn: ValueFQN, fields: Map[String, Sem]) extends Sem
+
+  /** A closure: a lambda value waiting to be applied. */
+  case class Lam(paramName: String, dom: Sem, body: Closure) extends Sem
+
+  /** A neutral term: a head followed by a spine of arguments. Cannot be reduced further. */
+  case class Neut(head: Head, spine: Seq[Sem]) extends Sem
+
+  given Show[Sem] = {
+    case Lit(direct)          => direct.value.toString
+    case TypeUniv             => "Type"
+    case Struct(fqn, fields)  =>
+      s"${fqn.show}{${fields.map((k, v) => s"$k=${v.show}").mkString(", ")}}"
+    case Lam(name, dom, _)    => s"(λ$name: ${dom.show} → …)"
+    case Neut(head, spine)    =>
+      val headStr = head.show
+      if (spine.isEmpty) headStr
+      else s"$headStr(${spine.map(_.show).mkString(", ")})"
+  }
+}

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/util/Evaluator2.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/util/Evaluator2.scala
@@ -1,0 +1,99 @@
+package com.vanillasource.eliot.eliotc.eval2.util
+
+import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.eval.fact.Types
+import com.vanillasource.eliot.eliotc.eval2.fact.*
+import com.vanillasource.eliot.eliotc.eval2.util.MetaState.EvalIO
+import com.vanillasource.eliot.eliotc.module.fact.ValueFQN
+import com.vanillasource.eliot.eliotc.operator.fact.{OperatorResolvedExpression, OperatorResolvedValue}
+import com.vanillasource.eliot.eliotc.processor.CompilerIO.*
+import com.vanillasource.eliot.eliotc.source.content.Sourced
+
+object Evaluator2 {
+
+  /** Evaluate an OperatorResolvedExpression to its semantic normal form. */
+  def eval(env: Env, expr: OperatorResolvedExpression): EvalIO[Sem] = expr match {
+    case OperatorResolvedExpression.IntegerLiteral(s) =>
+      Sem.Lit(com.vanillasource.eliot.eliotc.eval.fact.Value.Direct(s.value, Types.bigIntType)).pure[EvalIO]
+
+    case OperatorResolvedExpression.StringLiteral(s) =>
+      Sem.Lit(com.vanillasource.eliot.eliotc.eval.fact.Value.Direct(s.value, Types.stringType)).pure[EvalIO]
+
+    case OperatorResolvedExpression.ParameterReference(s) =>
+      env.params.get(s.value) match {
+        case Some(sem) => sem.pure[EvalIO]
+        case None      => Sem.Neut(Head.Param(s.value), Seq.empty).pure[EvalIO]
+      }
+
+    case OperatorResolvedExpression.ValueReference(s, typeArgs) =>
+      evalValueReference(env, s, typeArgs)
+
+    case OperatorResolvedExpression.FunctionApplication(target, arg) =>
+      for {
+        targetSem <- eval(env, target.value)
+        argSem    <- eval(env, arg.value)
+        result    <- apply(targetSem, argSem)
+      } yield result
+
+    case OperatorResolvedExpression.FunctionLiteral(paramName, paramTypeOpt, body) =>
+      for {
+        dom <- paramTypeOpt match {
+                 case Some(pt) => eval(env, pt.value.signature)
+                 case None     => (Sem.TypeUniv: Sem).pure[EvalIO]
+               }
+      } yield Sem.Lam(paramName.value, dom, Closure(env, body.value))
+  }
+
+  /** Apply a semantic function to an argument. Performs beta reduction for lambdas,
+    * extends the spine for neutral terms.
+    */
+  def apply(f: Sem, arg: Sem): EvalIO[Sem] = f match {
+    case Sem.Lam(name, _, Closure(closureEnv, body)) =>
+      eval(closureEnv.extend(name, arg), body)
+    case Sem.Neut(head, spine)                        =>
+      Sem.Neut(head, spine :+ arg).pure[EvalIO]
+    case _                                            =>
+      Sem.Neut(Head.Param("$apply-error"), Seq(f, arg)).pure[EvalIO]
+  }
+
+  private def evalValueReference(
+      env: Env,
+      vfqnSourced: Sourced[ValueFQN],
+      typeArgs: Seq[Sourced[OperatorResolvedExpression]]
+  ): EvalIO[Sem] = {
+    val vfqn = vfqnSourced.value
+    if (vfqn === Types.typeFQN) {
+      applyTypeArgs(env, Sem.TypeUniv, typeArgs)
+    } else {
+      for {
+        inProg <- MetaState.isInProgress(vfqn)
+        result <- if (inProg) {
+                    applyTypeArgs(env, Sem.Neut(Head.Ref(vfqn), Seq.empty), typeArgs)
+                  } else {
+                    MetaState.withInProgress(vfqn) {
+                      for {
+                        resolved <- MetaState.lift(
+                                      getFactOrAbort[OperatorResolvedValue, OperatorResolvedValue.Key](
+                                        OperatorResolvedValue.Key(vfqn)
+                                      )
+                                    )
+                        sem      <- resolved.runtime match {
+                                      case Some(body) => eval(Env.empty, body.value)
+                                      case None       => Sem.Neut(Head.Ref(vfqn), Seq.empty).pure[EvalIO]
+                                    }
+                      } yield sem
+                    }.flatMap(sem => applyTypeArgs(env, sem, typeArgs))
+                  }
+      } yield result
+    }
+  }
+
+  private def applyTypeArgs(
+      env: Env,
+      sem: Sem,
+      typeArgs: Seq[Sourced[OperatorResolvedExpression]]
+  ): EvalIO[Sem] =
+    typeArgs.foldLeftM(sem) { (acc, ta) =>
+      eval(env, ta.value).flatMap(apply(acc, _))
+    }
+}

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/util/MetaState.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/util/MetaState.scala
@@ -1,0 +1,29 @@
+package com.vanillasource.eliot.eliotc.eval2.util
+
+import cats.data.StateT
+import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.module.fact.ValueFQN
+import com.vanillasource.eliot.eliotc.processor.CompilerIO.CompilerIO
+
+/** State threaded through NbE evaluation. Tracks in-progress top-level definitions
+  * to detect recursion.
+  */
+case class MetaState(
+    inProgress: Set[ValueFQN] = Set.empty
+)
+
+object MetaState {
+  type EvalIO[A] = StateT[CompilerIO, MetaState, A]
+
+  def withInProgress[A](vfqn: ValueFQN)(action: EvalIO[A]): EvalIO[A] =
+    for {
+      _      <- StateT.modify[CompilerIO, MetaState](s => s.copy(inProgress = s.inProgress + vfqn))
+      result <- action
+      _      <- StateT.modify[CompilerIO, MetaState](s => s.copy(inProgress = s.inProgress - vfqn))
+    } yield result
+
+  def isInProgress(vfqn: ValueFQN): EvalIO[Boolean] =
+    StateT.inspect[CompilerIO, MetaState, Boolean](_.inProgress.contains(vfqn))
+
+  def lift[A](fa: CompilerIO[A]): EvalIO[A] = StateT.liftF(fa)
+}

--- a/lang/src/com/vanillasource/eliot/eliotc/eval2/util/Quoter.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/eval2/util/Quoter.scala
@@ -1,0 +1,29 @@
+package com.vanillasource.eliot.eliotc.eval2.util
+
+import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.eval.fact.Types
+import com.vanillasource.eliot.eliotc.eval.fact.Value
+import com.vanillasource.eliot.eliotc.eval2.fact.*
+import com.vanillasource.eliot.eliotc.eval2.util.MetaState.EvalIO
+
+/** Converts a fully-solved Sem to a Value. Returns None if any meta is unsolved
+  * or any free parameter remains.
+  */
+object Quoter {
+
+  def quote(sem: Sem): EvalIO[Option[Value]] = sem match {
+    case Sem.Lit(direct)         => (Some(direct): Option[Value]).pure[EvalIO]
+    case Sem.TypeUniv            => (Some(Value.Type): Option[Value]).pure[EvalIO]
+    case Sem.Struct(fqn, fields) =>
+      fields.toSeq
+        .traverse { case (k, v) => quote(v).map(_.map(k -> _)) }
+        .map { quotedOpts =>
+          quotedOpts.sequence.map { quotedFields =>
+            val fieldsMap = quotedFields.toMap + ("$typeName" -> Value.Direct(fqn, Types.fullyQualifiedNameType))
+            Value.Structure(fieldsMap, Value.Type)
+          }
+        }
+    case Sem.Lam(_, _, _)        => (None: Option[Value]).pure[EvalIO]
+    case Sem.Neut(_, _)          => (None: Option[Value]).pure[EvalIO]
+  }
+}

--- a/lang/test/src/com/vanillasource/eliot/eliotc/eval2/util/Evaluator2Test.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/eval2/util/Evaluator2Test.scala
@@ -1,0 +1,270 @@
+package com.vanillasource.eliot.eliotc.eval2.util
+
+import cats.data.{Chain, NonEmptySeq}
+import cats.effect.IO
+import com.vanillasource.eliot.eliotc.ProcessorTest
+import com.vanillasource.eliot.eliotc.core.fact.{QualifiedName, Qualifier, TypeStack}
+import com.vanillasource.eliot.eliotc.eval.fact.Types.{bigIntType, stringType}
+import com.vanillasource.eliot.eliotc.eval.fact.Value
+import com.vanillasource.eliot.eliotc.eval2.fact.*
+import com.vanillasource.eliot.eliotc.module.fact.{ModuleName, ValueFQN}
+import com.vanillasource.eliot.eliotc.operator.fact.{OperatorResolvedExpression, OperatorResolvedValue}
+import com.vanillasource.eliot.eliotc.processor.CompilerFact
+import com.vanillasource.eliot.eliotc.resolve.fact.{QualifiedName as RQualifiedName, Qualifier as RQualifier}
+import com.vanillasource.eliot.eliotc.source.content.Sourced
+
+class Evaluator2Test extends ProcessorTest() {
+
+  "evaluator2" should "evaluate integer literal" in {
+    runEval(intLit(42)).asserting(_ shouldBe Sem.Lit(Value.Direct(42, bigIntType)))
+  }
+
+  it should "evaluate string literal" in {
+    runEval(strLit("hello")).asserting(_ shouldBe Sem.Lit(Value.Direct("hello", stringType)))
+  }
+
+  it should "evaluate unbound parameter reference to neutral" in {
+    runEval(paramRef("x")).asserting(_ shouldBe Sem.Neut(Head.Param("x"), Seq.empty))
+  }
+
+  it should "evaluate bound parameter reference from environment" in {
+    val env = Env.empty.extend("x", Sem.Lit(Value.Direct(42, bigIntType)))
+    runEvalInEnv(env, paramRef("x")).asserting(_ shouldBe Sem.Lit(Value.Direct(42, bigIntType)))
+  }
+
+  it should "evaluate function literal to lambda" in {
+    runEval(funLit("x", intTypeRef, paramRef("x"))).asserting {
+      case Sem.Lam("x", _, Closure(_, _)) => succeed
+      case other                          => fail(s"Expected Lam, got: $other")
+    }
+  }
+
+  it should "evaluate unannotated function literal" in {
+    runEval(unannotatedFunLit("x", paramRef("x"))).asserting {
+      case Sem.Lam("x", Sem.TypeUniv, _) => succeed
+      case other                          => fail(s"Expected Lam with TypeUniv dom, got: $other")
+    }
+  }
+
+  it should "beta-reduce function application" in {
+    val fn   = funLit("x", intTypeRef, paramRef("x"))
+    val expr = funApp(fn, intLit(42))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(42, bigIntType)))
+  }
+
+  it should "beta-reduce nested function applications" in {
+    val fn   = funLit("x", intTypeRef, funLit("y", intTypeRef, paramRef("x")))
+    val expr = funApp(funApp(fn, intLit(1)), intLit(2))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(1, bigIntType)))
+  }
+
+  it should "return inner parameter in nested application" in {
+    val fn   = funLit("x", intTypeRef, funLit("y", intTypeRef, paramRef("y")))
+    val expr = funApp(funApp(fn, intLit(1)), intLit(2))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(2, bigIntType)))
+  }
+
+  it should "handle partial application" in {
+    val fn   = funLit("x", intTypeRef, funLit("y", intTypeRef, paramRef("x")))
+    val expr = funApp(fn, intLit(42))
+    runEval(expr).asserting {
+      case Sem.Lam("y", _, Closure(env, _)) =>
+        env.params.get("x") shouldBe Some(Sem.Lit(Value.Direct(42, bigIntType)))
+      case other                            => fail(s"Expected Lam, got: $other")
+    }
+  }
+
+  it should "handle shadowed parameters" in {
+    val fn   = funLit("x", intTypeRef, funLit("x", intTypeRef, paramRef("x")))
+    val expr = funApp(funApp(fn, intLit(1)), intLit(2))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(2, bigIntType)))
+  }
+
+  it should "apply neutral term to argument" in {
+    val expr = funApp(paramRef("f"), intLit(42))
+    runEval(expr).asserting(_ shouldBe Sem.Neut(Head.Param("f"), Seq(Sem.Lit(Value.Direct(42, bigIntType)))))
+  }
+
+  it should "accumulate spine for multiple applications to neutral" in {
+    val expr = funApp(funApp(paramRef("f"), intLit(1)), intLit(2))
+    runEval(expr).asserting(
+      _ shouldBe Sem.Neut(
+        Head.Param("f"),
+        Seq(Sem.Lit(Value.Direct(1, bigIntType)), Sem.Lit(Value.Direct(2, bigIntType)))
+      )
+    )
+  }
+
+  it should "resolve value reference with runtime body" in {
+    val vfqn    = ValueFQN(testModuleName, QualifiedName("zero", Qualifier.Default))
+    val orv     = makeORV(vfqn, Some(intLit(0)), intTypeRef)
+    runEvalWithFacts(valueRef(vfqn), Seq(orv)).asserting(
+      _ shouldBe Sem.Lit(Value.Direct(BigInt(0), bigIntType))
+    )
+  }
+
+  it should "resolve value reference without runtime to neutral" in {
+    val vfqn = ValueFQN(testModuleName, QualifiedName("opaque_val", Qualifier.Default))
+    val orv  = makeORV(vfqn, None, intTypeRef)
+    runEvalWithFacts(valueRef(vfqn), Seq(orv)).asserting(
+      _ shouldBe Sem.Neut(Head.Ref(vfqn), Seq.empty)
+    )
+  }
+
+  it should "detect direct recursion and return neutral" in {
+    val vfqn = ValueFQN(testModuleName, QualifiedName("rec", Qualifier.Default))
+    val orv  = makeORV(vfqn, Some(valueRef(vfqn)), intTypeRef)
+    runEvalWithFacts(valueRef(vfqn), Seq(orv)).asserting(
+      _ shouldBe Sem.Neut(Head.Ref(vfqn), Seq.empty)
+    )
+  }
+
+  it should "detect mutual recursion and return neutral" in {
+    val vfqnA = ValueFQN(testModuleName, QualifiedName("a", Qualifier.Default))
+    val vfqnB = ValueFQN(testModuleName, QualifiedName("b", Qualifier.Default))
+    val orvA  = makeORV(vfqnA, Some(valueRef(vfqnB)), intTypeRef)
+    val orvB  = makeORV(vfqnB, Some(valueRef(vfqnA)), intTypeRef)
+    runEvalWithFacts(valueRef(vfqnA), Seq(orvA, orvB)).asserting(
+      _ shouldBe Sem.Neut(Head.Ref(vfqnA), Seq.empty)
+    )
+  }
+
+  it should "resolve function value reference and apply" in {
+    val vfqn  = ValueFQN(testModuleName, QualifiedName("identity", Qualifier.Default))
+    val idFn  = funLit("x", intTypeRef, paramRef("x"))
+    val orv   = makeORV(vfqn, Some(idFn), intTypeRef)
+    val expr  = funApp(valueRef(vfqn), intLit(42))
+    runEvalWithFacts(expr, Seq(orv)).asserting(
+      _ shouldBe Sem.Lit(Value.Direct(42, bigIntType))
+    )
+  }
+
+  it should "apply type arguments to value reference" in {
+    val vfqn    = ValueFQN(testModuleName, QualifiedName("poly", Qualifier.Default))
+    val polyFn  = funLit("A", typeTypeRef, funLit("a", paramRef("A"), paramRef("a")))
+    val orv     = makeORV(vfqn, Some(polyFn), typeTypeRef)
+    val expr    = valueRefWithTypeArgs(vfqn, Seq(intTypeRef))
+    runEvalWithFacts(expr, Seq(orv, intTypeORV)).asserting {
+      case Sem.Lam("a", _, _) => succeed
+      case other              => fail(s"Expected Lam after type arg application, got: $other")
+    }
+  }
+
+  it should "reduce complex nested expression" in {
+    val const = funLit("x", intTypeRef, funLit("y", intTypeRef, paramRef("x")))
+    val expr  = funApp(funApp(const, intLit(1)), intLit(2))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(1, bigIntType)))
+  }
+
+  it should "evaluate deeply nested function applications" in {
+    val id   = funLit("x", intTypeRef, paramRef("x"))
+    val expr = funApp(funApp(funApp(funApp(id, id), id), id), intLit(42))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(42, bigIntType)))
+  }
+
+  it should "correctly substitute in complex body" in {
+    val fn   = funLit("x", intTypeRef, funApp(funLit("y", intTypeRef, paramRef("x")), paramRef("x")))
+    val expr = funApp(fn, intLit(99))
+    runEval(expr).asserting(_ shouldBe Sem.Lit(Value.Direct(99, bigIntType)))
+  }
+
+  // --- Helpers ---
+
+  private val intTypeFQN    = ValueFQN(
+    ModuleName(Seq("eliot", "lang"), "BigInteger"),
+    QualifiedName("BigInteger", Qualifier.Type)
+  )
+  private val stringTypeFQN = ValueFQN(
+    ModuleName(Seq("eliot", "lang"), "String"),
+    QualifiedName("String", Qualifier.Type)
+  )
+  private val typeTypeFQN   = ValueFQN(
+    ModuleName(Seq("eliot", "lang"), "Type"),
+    QualifiedName("Type", Qualifier.Type)
+  )
+  private val intTypeRef    = valueRef(intTypeFQN)
+  private val typeTypeRef   = valueRef(typeTypeFQN)
+  private val intTypeORV    = makeORV(intTypeFQN, None, typeTypeRef)
+  private val stringTypeORV = makeORV(stringTypeFQN, None, typeTypeRef)
+  private val baseFacts: Seq[CompilerFact] = Seq(intTypeORV, stringTypeORV)
+
+  private def intLit(value: BigInt): OperatorResolvedExpression =
+    OperatorResolvedExpression.IntegerLiteral(sourced(value))
+
+  private def strLit(value: String): OperatorResolvedExpression =
+    OperatorResolvedExpression.StringLiteral(sourced(value))
+
+  private def paramRef(name: String): OperatorResolvedExpression =
+    OperatorResolvedExpression.ParameterReference(sourced(name))
+
+  private def valueRef(vfqn: ValueFQN): OperatorResolvedExpression =
+    OperatorResolvedExpression.ValueReference(sourced(vfqn))
+
+  private def valueRefWithTypeArgs(
+      vfqn: ValueFQN,
+      typeArgs: Seq[OperatorResolvedExpression]
+  ): OperatorResolvedExpression =
+    OperatorResolvedExpression.ValueReference(sourced(vfqn), typeArgs.map(sourced))
+
+  private def funLit(
+      param: String,
+      paramTypeExpr: OperatorResolvedExpression,
+      body: OperatorResolvedExpression
+  ): OperatorResolvedExpression =
+    OperatorResolvedExpression.FunctionLiteral(
+      sourced(param),
+      Some(sourced(TypeStack(NonEmptySeq.of(paramTypeExpr)))),
+      sourced(body)
+    )
+
+  private def unannotatedFunLit(
+      param: String,
+      body: OperatorResolvedExpression
+  ): OperatorResolvedExpression =
+    OperatorResolvedExpression.FunctionLiteral(
+      sourced(param),
+      None,
+      sourced(body)
+    )
+
+  private def funApp(
+      target: OperatorResolvedExpression,
+      arg: OperatorResolvedExpression
+  ): OperatorResolvedExpression =
+    OperatorResolvedExpression.FunctionApplication(sourced(target), sourced(arg))
+
+  private def makeORV(
+      vfqn: ValueFQN,
+      runtime: Option[OperatorResolvedExpression],
+      signatureExpr: OperatorResolvedExpression
+  ): OperatorResolvedValue =
+    OperatorResolvedValue(
+      vfqn,
+      sourced(RQualifiedName(vfqn.name.name, RQualifier.Default)),
+      runtime.map(sourced),
+      sourced(TypeStack(NonEmptySeq.of(signatureExpr)))
+    )
+
+  private def runEval(expr: OperatorResolvedExpression): IO[Sem] =
+    runEvalWithFacts(expr, Seq.empty)
+
+  private def runEvalInEnv(env: Env, expr: OperatorResolvedExpression): IO[Sem] =
+    runEvalInEnvWithFacts(env, expr, Seq.empty)
+
+  private def runEvalWithFacts(expr: OperatorResolvedExpression, facts: Seq[CompilerFact]): IO[Sem] =
+    runEvalInEnvWithFacts(Env.empty, expr, facts)
+
+  private def runEvalInEnvWithFacts(
+      env: Env,
+      expr: OperatorResolvedExpression,
+      facts: Seq[CompilerFact]
+  ): IO[Sem] =
+    for {
+      generator <- createGenerator(baseFacts ++ facts)
+      result    <- Evaluator2.eval(env, expr).run(MetaState()).run(generator).run(Chain.empty).value
+    } yield result match {
+      case Right((_, (_, sem))) => sem
+      case Left(errors)         =>
+        throw Exception(s"Evaluation failed: ${errors.toList.map(_.message).mkString(", ")}")
+    }
+}

--- a/lang/test/src/com/vanillasource/eliot/eliotc/eval2/util/QuoterTest.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/eval2/util/QuoterTest.scala
@@ -1,0 +1,100 @@
+package com.vanillasource.eliot.eliotc.eval2.util
+
+import cats.data.Chain
+import cats.effect.IO
+import com.vanillasource.eliot.eliotc.ProcessorTest
+import com.vanillasource.eliot.eliotc.core.fact.{QualifiedName, Qualifier}
+import com.vanillasource.eliot.eliotc.eval.fact.Types
+import com.vanillasource.eliot.eliotc.eval.fact.Types.{bigIntType, stringType}
+import com.vanillasource.eliot.eliotc.eval.fact.Value
+import com.vanillasource.eliot.eliotc.eval2.fact.*
+import com.vanillasource.eliot.eliotc.module.fact.{ModuleName, ValueFQN}
+import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedExpression
+
+class QuoterTest extends ProcessorTest() {
+
+  "quoter" should "quote Lit to Direct value" in {
+    val direct = Value.Direct(42, bigIntType)
+    runQuote(Sem.Lit(direct)).asserting(_ shouldBe Some(direct))
+  }
+
+  it should "quote string Lit" in {
+    val direct = Value.Direct("hello", stringType)
+    runQuote(Sem.Lit(direct)).asserting(_ shouldBe Some(direct))
+  }
+
+  it should "quote TypeUniv to Value.Type" in {
+    runQuote(Sem.TypeUniv).asserting(_ shouldBe Some(Value.Type))
+  }
+
+  it should "quote Struct to Value.Structure" in {
+    val fqn    = ValueFQN(
+      ModuleName(Seq("eliot", "lang"), "BigInteger"),
+      QualifiedName("BigInteger", Qualifier.Type)
+    )
+    val sem    = Sem.Struct(fqn, Map.empty)
+    runQuote(sem).asserting {
+      case Some(Value.Structure(fields, Value.Type)) =>
+        fields.get("$typeName") match {
+          case Some(Value.Direct(v: ValueFQN, _)) => v shouldBe fqn
+          case other                               => fail(s"Expected $$typeName field, got: $other")
+        }
+      case other                                     => fail(s"Expected Some(Structure), got: $other")
+    }
+  }
+
+  it should "quote Struct with fields" in {
+    val fqn = Types.functionDataTypeFQN
+    val sem = Sem.Struct(
+      fqn,
+      Map(
+        "A" -> Sem.Lit(Value.Direct(0, bigIntType)),
+        "B" -> Sem.TypeUniv
+      )
+    )
+    runQuote(sem).asserting {
+      case Some(Value.Structure(fields, Value.Type)) =>
+        fields("A") shouldBe Value.Direct(0, bigIntType)
+        fields("B") shouldBe Value.Type
+      case other                                     => fail(s"Expected Some(Structure), got: $other")
+    }
+  }
+
+  it should "return None for Lam" in {
+    val lam = Sem.Lam(
+      "x",
+      Sem.TypeUniv,
+      Closure(Env.empty, OperatorResolvedExpression.ParameterReference(sourced("x")))
+    )
+    runQuote(lam).asserting(_ shouldBe None)
+  }
+
+  it should "return None for Neut with Param head" in {
+    runQuote(Sem.Neut(Head.Param("x"), Seq.empty)).asserting(_ shouldBe None)
+  }
+
+  it should "return None for Neut with Ref head" in {
+    val vfqn = ValueFQN(testModuleName, QualifiedName("unknown", Qualifier.Default))
+    runQuote(Sem.Neut(Head.Ref(vfqn), Seq.empty)).asserting(_ shouldBe None)
+  }
+
+  it should "return None for Neut with Meta head" in {
+    runQuote(Sem.Neut(Head.Meta(MetaId(0)), Seq.empty)).asserting(_ shouldBe None)
+  }
+
+  it should "return None for Struct with unquotable field" in {
+    val fqn = Types.functionDataTypeFQN
+    val sem = Sem.Struct(fqn, Map("A" -> Sem.Neut(Head.Param("x"), Seq.empty)))
+    runQuote(sem).asserting(_ shouldBe None)
+  }
+
+  private def runQuote(sem: Sem): IO[Option[Value]] =
+    for {
+      generator <- createGenerator(Seq.empty)
+      result    <- Quoter.quote(sem).run(MetaState()).run(generator).run(Chain.empty).value
+    } yield result match {
+      case Right((_, (_, v))) => v
+      case Left(errors)       =>
+        throw Exception(s"Quote failed: ${errors.toList.map(_.message).mkString(", ")}")
+    }
+}


### PR DESCRIPTION
Evaluation) migration. This is a standalone implementation alongside the
existing eval package, not yet wired into the compilation pipeline.

Semantic domain (eval2/fact):
- Sem: sealed trait with Lit, TypeUniv, Struct, Lam, and Neut variants
  representing values in normal form, with metavariables as neutral heads
- Head: neutral term heads (Param, Meta, Ref) for stuck computations
- Closure: captures an environment and unevaluated body expression
- Env: parameter-name-to-Sem mapping for evaluation contexts
- MetaId: opaque Int identifier for unification metavariables

Evaluation utilities (eval2/util):
- Evaluator2: evaluates OperatorResolvedExpression to Sem, with beta
  reduction for lambdas, spine accumulation for neutrals, recursion
  detection via in-progress tracking, and type argument application
- Quoter: converts fully-solved Sem back to Value for downstream use,
  returning None for lambdas and unsolved neutrals
- MetaState: EvalIO monad (StateT[CompilerIO, MetaState, A]) threading
  in-progress set for recursion detection

Tests: 22 Evaluator2 tests covering literals, parameters, lambdas, beta
reduction, partial application, shadowing, neutral terms, value reference
resolution, recursion detection, and type arguments. 10 Quoter tests
covering all Sem variants including failure cases.

SHARED_TASK_NOTES.md documents current state and next steps (Phase 2:
metavariables and unifier).