### PR TITLE
Close namedValues recursion hole in the termination gate

### DIFF
--- a/lang/src/com/vanillasource/eliot/eliotc/termination/processor/RecursionChecker.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/termination/processor/RecursionChecker.scala
@@ -3,6 +3,7 @@ package com.vanillasource.eliot.eliotc.termination.processor
 import cats.{Id, Monad}
 import cats.syntax.all.*
 import com.vanillasource.eliot.eliotc.module.fact.ValueFQN
+import com.vanillasource.eliot.eliotc.namedvalues.fact.NamedValuesRewrittenValue
 import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedExpression.foldValueReferences
 import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedValue
 import com.vanillasource.eliot.eliotc.platform.Platform
@@ -72,9 +73,17 @@ class RecursionChecker {
 
   /** The body callees of an already-resolved value, or the empty set when it is body-less (a native) or cannot be
     * resolved (conservative: a leaf, so the search just stops there).
+    *
+    * Reads the *rewritten* fact (not the raw [[OperatorResolvedValue]]) so a callee's `namedValues` reflection is
+    * expanded into concrete reference edges here too — exactly as it already is for the root value under check. Reading
+    * the pre-rewrite fact would leave `namedValues` a body-less dead-end on every transitive node, letting a mutual
+    * cycle whose back-path runs through a second reflection (`f = namedValues("bar")`, `g = namedValues("foo")`) slip
+    * the gate. A value whose rewrite aborted (a `namedValues` error) produces no fact and is treated as a leaf, which is
+    * safe: that value already failed and never reaches monomorphization.
     */
   private def calleesOf(fqn: ValueFQN, platform: Platform): CompilerIO[Set[ValueFQN]] =
-    getFactIfProduced(OperatorResolvedValue.Key(fqn, platform)).map(_.fold(Set.empty[ValueFQN])(directCallees))
+    getFactIfProduced(NamedValuesRewrittenValue.Key(fqn, platform))
+      .map(_.fold(Set.empty[ValueFQN])(rewritten => directCallees(rewritten.value)))
 
   /** Every distinct [[ValueFQN]] referenced in a value's runtime body — head positions, arguments and type arguments
     * alike (the resolved value-reference graph). The type signature is deliberately excluded.

--- a/lang/test/src/com/vanillasource/eliot/eliotc/termination/RecursionCheckProcessorTest.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/termination/RecursionCheckProcessorTest.scala
@@ -1,0 +1,94 @@
+package com.vanillasource.eliot.eliotc.termination
+
+import cats.effect.IO
+import com.vanillasource.eliot.eliotc.ProcessorTest
+import com.vanillasource.eliot.eliotc.module.fact.{ModuleName, QualifiedName, Qualifier, ValueFQN, WellKnownTypes}
+import com.vanillasource.eliot.eliotc.namedvalues.NamedValues
+import com.vanillasource.eliot.eliotc.namedvalues.fact.NamedValuesIndex
+import com.vanillasource.eliot.eliotc.namedvalues.processor.NamedValuesRewriteProcessor
+import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedExpression
+import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedExpression.{FunctionApplication, StringLiteral, ValueReference}
+import com.vanillasource.eliot.eliotc.operator.fact.OperatorResolvedValue
+import com.vanillasource.eliot.eliotc.platform.Platform
+import com.vanillasource.eliot.eliotc.processor.CompilerFact
+import com.vanillasource.eliot.eliotc.resolve.fact.{Qualifier => RQualifier, QualifiedName => RQualifiedName}
+import com.vanillasource.eliot.eliotc.source.content.Sourced
+import com.vanillasource.eliot.eliotc.termination.fact.RecursionCheckedValue
+import com.vanillasource.eliot.eliotc.termination.processor.RecursionCheckProcessor
+
+/** Recursion-gate tests focused on the `namedValues` reflection edge. The gate reads the *rewritten* value (its
+  * `namedValues` calls already expanded into `ref(...)` edges), so a cycle that closes through reflection must be
+  * rejected exactly like a hand-written one — including a mutual cycle whose back-path runs through a *second*
+  * reflection, which slipped the gate while transitive callees were read from the pre-rewrite fact.
+  */
+class RecursionCheckProcessorTest extends ProcessorTest(NamedValuesRewriteProcessor(), RecursionCheckProcessor()) {
+  private val typeArg: Sourced[OperatorResolvedExpression] = sourced(ValueReference(sourced(WellKnownTypes.typeFQN)))
+
+  private def vfqn(module: String, name: String): ValueFQN =
+    ValueFQN(ModuleName(Seq("pkg"), module), QualifiedName(name, Qualifier.Default))
+
+  private def ref(fqn: ValueFQN): OperatorResolvedExpression = ValueReference(sourced(fqn))
+
+  /** `namedValues[Type](name)`. */
+  private def namedValuesCall(name: String): OperatorResolvedExpression =
+    FunctionApplication(
+      sourced(ValueReference(sourced(NamedValues.namedValuesFQN), Seq(typeArg))),
+      sourced(StringLiteral(sourced(name)))
+    )
+
+  /** An operator-resolved value `vfqn` named `name` with the given runtime body. */
+  private def value(vfqn: ValueFQN, name: String, body: OperatorResolvedExpression): OperatorResolvedValue =
+    OperatorResolvedValue(
+      vfqn,
+      sourced(RQualifiedName(name, RQualifier.Default)),
+      Some(sourced(body)),
+      sourced(ref(WellKnownTypes.typeFQN))
+    )
+
+  private def check(target: ValueFQN, facts: CompilerFact*): IO[(Option[RecursionCheckedValue], Seq[String])] =
+    runGeneratorWithFacts(facts, RecursionCheckedValue.Key(target, Platform.Runtime))
+      .map { case (result, errors) => (result, errors.map(_.message)) }
+
+  private val fFqn = vfqn("F", "foo")
+  private val gFqn = vfqn("G", "bar")
+
+  "the recursion gate" should "reject a value that reflects itself directly" in {
+    check(
+      fFqn,
+      NamedValuesIndex("foo", Platform.Runtime, Seq(fFqn)),
+      value(fFqn, "foo", namedValuesCall("foo"))
+    ).asserting { case (result, errors) =>
+      result shouldBe None
+      errors shouldBe Seq("Value 'foo' is defined recursively.")
+    }
+  }
+
+  it should "reject a mutual cycle whose back-path runs through a second reflection" in {
+    // `foo = namedValues("bar")` and `bar = namedValues("foo")`: the runtime cycle foo -> bar -> foo closes through two
+    // reflections. The transitive `bar` node must be read rewritten, else its `namedValues` is a body-less dead-end and
+    // the cycle slips the gate.
+    check(
+      fFqn,
+      NamedValuesIndex("bar", Platform.Runtime, Seq(gFqn)),
+      NamedValuesIndex("foo", Platform.Runtime, Seq(fFqn)),
+      value(fFqn, "foo", namedValuesCall("bar")),
+      value(gFqn, "bar", namedValuesCall("foo"))
+    ).asserting { case (result, errors) =>
+      result shouldBe None
+      errors shouldBe Seq("Value 'foo' is defined recursively.")
+    }
+  }
+
+  it should "accept a reflection that does not cycle back" in {
+    // `foo = namedValues("bar")`, and `bar` reflects nothing — no path back to `foo`.
+    check(
+      fFqn,
+      NamedValuesIndex("bar", Platform.Runtime, Seq(gFqn)),
+      value(fFqn, "foo", namedValuesCall("bar")),
+      value(gFqn, "bar", ref(WellKnownTypes.typeFQN))
+    ).asserting { case (result, errors) =>
+      result.map(_.value.vfqn) shouldBe Some(fFqn)
+      errors shouldBe Seq.empty
+    }
+  }
+}


### PR DESCRIPTION
RecursionChecker expanded `namedValues` reflection only for the root value
under check (read from NamedValuesRewrittenValue) but read every transitive
callee from the pre-rewrite OperatorResolvedValue, where `namedValues` is a
body-less intrinsic that dead-ends the graph walk. A mutual cycle whose
back-path runs through a second reflection (`f = namedValues("bar")`,
`g = namedValues("foo")`) therefore slipped the gate and reached
monomorphization/codegen as genuine recursion.

Read the rewritten fact in `calleesOf` so reflection is expanded uniformly on
transitive nodes too. A value whose rewrite aborted produces no fact and is
treated as a leaf, which is safe: it already failed and never reaches
monomorphization.

Add RecursionCheckProcessorTest covering direct self-reflection, the
double-reflection mutual cycle (the regression), and a non-cyclic reflection.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012nRbC6EQuZphCyudFH59VY