### PR TITLE
Document that printLine cannot fail; drop the resolved TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,10 +56,6 @@ notes.
 
 - Separate the different kinds of I/O (pin output, pin input, timers, …) and let the type
   system infer multiple typeclasses for them.
-- **`printLine` can fail, and nothing says so.** Console output can throw on the platform, so it
-  needs error handling in the row. Does that failure belong on `Suspend`, or as its own effect
-  beside `Console`? (Related to the deliberate decision that console *read* failure stays out of
-  the row — see the `Console` EOF work.)
 - A plain `if..else` needs an effect carrier — it cannot be pure.
 - **A lambda body at a rowless arrow slot does not get its own pure region.** It is elaborated in
   the *enclosing* region, so a discharge written inline there lands on the caller's carrier

--- a/stdlib/eliot/eliot/effect/Console.els
+++ b/stdlib/eliot/eliot/effect/Console.els
@@ -25,6 +25,11 @@
 ability Console[F[_]] {
    /**
     * Write `s` to standard output, followed by a line separator.
+    *
+    * There is no failure channel: `printLine` cannot fail from the program's point of view. A write that
+    * breaks underneath a running program (a closed stream, a severed pipe) is an environment failure the
+    * program cannot meaningfully act on, so it terminates the program rather than entering the `{Console}`
+    * row — the same stance every mainstream runtime takes for standard output.
     */
    def printLine(s: String): {Console} Unit
 


### PR DESCRIPTION
Console output failures (closed stream, severed pipe) are environment
failures a program cannot act on, so they terminate the program rather
than entering the {Console} row. State this explicitly on printLine's
doc comment, mirroring the ability-level rationale and the readLine EOF
stance, and remove the now-answered TODO item.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RuRiZRpLxjPaapQK1zqbzN