### PR TITLE
Make || bind looser than &&

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -97,7 +97,6 @@ notes.
 - **Importing a module should bring in the abilities it implements.** When a module implements an
   ability, that ability's functions should become available through the import — e.g. `import
   BigInteger` would also get you `Compare` and `Numeric`.
-- `&&` and `||` currently have the same precedence; `||` should bind looser than `&&`.
 - `a-1` does not parse as `a - 1`.
 
 ## Optimization

--- a/stdlib/eliot/eliot/lang/Bool.els
+++ b/stdlib/eliot/eliot/lang/Bool.els
@@ -15,11 +15,10 @@ infix left def &&(a: Bool, b: Bool): Bool
 /**
  * Logical disjunction: `true` when at least one of `a` and `b` is `true`.
  *
- * `||` sits at the *same* precedence as `&&` (unlike most languages, where `&&` binds tighter), so a mixed chain
- * groups left to right: `a || b && c` is `(a || b) && c` — parenthesise when you mean `a || (b && c)`. Operands
- * are ordinary values; there is no short-circuiting.
+ * `||` binds *looser* than `&&` (as in most languages), so a mixed chain groups by conjunction first:
+ * `a || b && c` is `a || (b && c)`. Operands are ordinary values; there is no short-circuiting.
  */
-infix left at && def ||(a: Bool, b: Bool): Bool
+infix left below && def ||(a: Bool, b: Bool): Bool
 
 /**
  * Logical negation: `true` becomes `false` and `false` becomes `true`.


### PR DESCRIPTION
`&&` and `||` previously shared the same precedence, so a mixed chain like
`a || b && c` grouped left-to-right as `(a || b) && c`. Change `||`'s fixity
from `at &&` to `below &&`, matching the conventional precedence in which
conjunction binds tighter than disjunction — `a || b && c` is now
`a || (b && c)`. Update the doc comment and remove the TODO item.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Az4iqaCpQaMUB95PVHD3FB