### PR TITLE
Totalize NativeBinding fact (retire-optional-fact-reads step 1)

### DIFF
--- a/docs/retire-optional-fact-reads.md
+++ b/docs/retire-optional-fact-reads.md
@@ -1,6 +1,11 @@
 # Retiring the Optional Fact Read (`getFactIfProduced`)
 
-Status: **PLAN (2026-08-02); nothing landed.** Written against the current tree.
+Status: **PLAN (2026-08-02); step 1 landed.** Written against the current tree. §6.1 (the `NativeBinding`
+totalization) is done: the fact now carries `semValue: Option[SemValue]`, `BindingMergerProcessor` publishes a
+`None` payload instead of aborting, and the Bucket-1 readers (`MonomorphicTypeCheckProcessor`,
+`CompilerMonomorphicTypeCheckProcessor`) read it with `getFactOrAbort`. The Bucket-3 cyclic-walk readers
+(`BindingClosure`, `ReducedBindingClosure`) stay tolerant and only inspect the new `Option` payload. The rest is
+still open.
 
 ## 1. The problem, restated
 
@@ -143,7 +148,7 @@ value, not merely a drillable one; decline-caching is the safety net for the gen
 ## 6. Sequencing
 
 1. **Finish the natives** (`NativeBinding` total + its ~5 readers). Smallest, self-contained, and the worked
-   example for the rest. Measure warm-build regeneration count before/after.
+   example for the rest. Measure warm-build regeneration count before/after. **✓ Done.**
 2. **Bucket 1 remainder** (module membership, ability lookups). Biggest cache win.
 3. **Bucket 2.**
 4. **Bucket 3 rename** (cheap; makes intent explicit and prevents backsliding).

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/fact/NativeBinding.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/fact/NativeBinding.scala
@@ -13,16 +13,22 @@ import com.vanillasource.eliot.eliotc.processor.{CompilerFact, CompilerFactKey}
   * reach a runtime-only body — the native-leaf boundary. The runtime track ([[Platform.Runtime]], the default) merges
   * the native suppliers over the runtime `user` bodies exactly as before.
   *
+  * The fact is *total*: the [[com.vanillasource.eliot.eliotc.monomorphize.processor.BindingMergerProcessor]] answers
+  * `semValue = None` for a name no supplier binds rather than declining, so readers request it with `getFactOrAbort`
+  * and inspect the payload — a `None` payload is a domain answer ("no binding; evaluation leaves it stuck at the use
+  * site"), never a missing fact. Keeping the fact total also removes the cache-poison edge a decline leaves behind
+  * (see `docs/retire-optional-fact-reads.md`).
+  *
   * @param vfqn
   *   The fully qualified name of the value
   * @param semValue
-  *   The semantic value for NbE evaluation
+  *   The semantic value for NbE evaluation, or `None` if no supplier binds `vfqn`
   * @param platform
   *   The source pool this binding was merged for
   */
 case class NativeBinding(
     vfqn: ValueFQN,
-    semValue: SemValue,
+    semValue: Option[SemValue],
     platform: Platform = Platform.Runtime
 ) extends CompilerFact {
   override def key(): CompilerFactKey[NativeBinding] =

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/BindingClosure.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/BindingClosure.scala
@@ -114,7 +114,7 @@ object BindingClosure {
             acc.pure[CompilerIO]
           else
             getFactIfProduced(NativeBinding.Key(vfqn.value, platform)).map {
-              case Some(binding) => acc + (vfqn.value -> binding.semValue)
+              case Some(binding) => binding.semValue.fold(acc)(sv => acc + (vfqn.value -> sv))
               case None          => acc
             }
         }

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/BindingMergerProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/BindingMergerProcessor.scala
@@ -21,7 +21,9 @@ import com.vanillasource.eliot.eliotc.processor.common.SingleFactProcessor
   *     the use site, never as a producer-side judgment.
   *
   * Selection is pure precedence with no conflict resolution: the first native `Some` → else the first user `Some` →
-  * else abort (no binding; the evaluator stalls at the use site — the companion-clause, use-site error). Uniqueness
+  * else an absent binding (a `NativeBinding` with `semValue = None`; the evaluator stalls at the use site — the
+  * companion-clause, use-site error). The output [[NativeBinding]] is *total* — no name declines — so the fact never
+  * leaves a cache-poison edge and readers consume it with [[getFactOrAbort]]. Uniqueness
   * already holds within each category (native suppliers are disjoint by construction; the user stack is
   * single-implementation by layering), so each category yields at most one value and there is nothing to order or
   * reject. A user body coexisting with a native is the normal case (`add` has a compile-time native and a runtime
@@ -63,10 +65,10 @@ class BindingMergerProcessor(nativeLabels: Seq[String], userLabels: Seq[String])
                       }
                   }
       semValue <- selected match {
-                    case Some(BindingContribution.Leaf(value))     => value.pure[CompilerIO]
+                    case Some(BindingContribution.Leaf(value))     => value.some.pure[CompilerIO]
                     case Some(BindingContribution.Body(saturated)) =>
-                      BindingClosure.buildBinding(saturated, _.runtime, key.platform)
-                    case None                                      => abort[SemValue]
+                      BindingClosure.buildBinding(saturated, _.runtime, key.platform).map(_.some)
+                    case None                                      => none[SemValue].pure[CompilerIO]
                   }
     } yield NativeBinding(key.vfqn, semValue, key.platform)
 }

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerMonomorphicTypeCheckProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerMonomorphicTypeCheckProcessor.scala
@@ -58,21 +58,21 @@ class CompilerMonomorphicTypeCheckProcessor()
     * and stays `None`.
     */
   private def fetchBinding(source: Sourced[?])(vfqn: ValueFQN): CompilerIO[Option[SemValue]] =
-    getFactIfProduced(NativeBinding.Key(vfqn, Platform.Compiler)).flatMap {
-      case Some(nb) => Option(nb.semValue).pure[CompilerIO]
-      case None     =>
+    getFactOrAbort(NativeBinding.Key(vfqn, Platform.Compiler)).flatMap {
+      case NativeBinding(_, some @ Some(_), _) => some.pure[CompilerIO]
+      case NativeBinding(_, None, _)           =>
         inRuntimePool(vfqn).ifM(
-          getFactIfProduced(NativeBinding.Key(vfqn, Platform.Runtime)).flatMap {
-            case Some(_) =>
+          getFactOrAbort(NativeBinding.Key(vfqn, Platform.Runtime)).flatMap {
+            case NativeBinding(_, Some(_), _) =>
               compilerError(
                 source.as(s"Cannot use runtime-only value '${vfqn.name.name}' at compile time."),
                 Seq(
                   s"'${vfqn.name.name}' has a runtime implementation but no compile-time definition on the compiler platform."
                 )
               ) >> abort[Option[SemValue]]
-            case None    => Option.empty[SemValue].pure[CompilerIO] // a runtime member abstract on *both* platforms
+            case NativeBinding(_, None, _)    => Option.empty[SemValue].pure[CompilerIO] // abstract on *both* platforms
           },
-          Option.empty[SemValue].pure[CompilerIO]                   // not a runtime member: compiler-only, not a leaf
+          Option.empty[SemValue].pure[CompilerIO]                                        // compiler-only, not a leaf
         )
     }
 

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/MonomorphicTypeCheckProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/MonomorphicTypeCheckProcessor.scala
@@ -19,7 +19,7 @@ class MonomorphicTypeCheckProcessor()
     extends TransformationProcessor[SaturatedValue.Key, MonomorphicValue.Key](key => SaturatedValue.Key(key.vfqn)) {
 
   private def fetchBinding(vfqn: ValueFQN): CompilerIO[Option[SemValue]] =
-    getFactIfProduced(NativeBinding.Key(vfqn, Platform.Runtime)).map(_.map(_.semValue))
+    getFactOrAbort(NativeBinding.Key(vfqn, Platform.Runtime)).map(_.semValue)
 
   override protected def generateFromKeyAndFact(
       key: MonomorphicValue.Key,

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/ReducedBindingClosure.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/ReducedBindingClosure.scala
@@ -98,7 +98,7 @@ object ReducedBindingClosure {
           else {
             def raw: CompilerIO[Map[ValueFQN, SemValue]] =
               getFactIfProduced(NativeBinding.Key(fqn, platform)).map {
-                case Some(binding) => acc + (fqn -> binding.semValue)
+                case Some(binding) => binding.semValue.fold(acc)(sv => acc + (fqn -> sv))
                 case None          => acc
               }
             if (deep)

--- a/lang/test/src/com/vanillasource/eliot/eliotc/monomorphize/check/CarrierBookkeepingTest.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/monomorphize/check/CarrierBookkeepingTest.scala
@@ -99,7 +99,7 @@ object CarrierBookkeepingTest {
       extends TransformationProcessor[SaturatedValue.Key, CarrierProbe.Key](key => SaturatedValue.Key(key.vfqn)) {
 
     private def fetchBinding(vfqn: ValueFQN): CompilerIO[Option[SemValue]] =
-      getFactIfProduced(NativeBinding.Key(vfqn, Platform.Runtime)).map(_.map(_.semValue))
+      getFactOrAbort(NativeBinding.Key(vfqn, Platform.Runtime)).map(_.semValue)
 
     private def resolveAbilityImpl(
         vfqn: ValueFQN,

--- a/lang/test/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerNativesProcessorTest.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerNativesProcessorTest.scala
@@ -68,7 +68,7 @@ class CompilerNativesProcessorTest extends ProcessorTest(LangProcessors(systemMo
   }
 
   it should "reduce a name during checking off its compiler-platform body (native wins over the runtime user body)" in {
-    fact(NativeBinding.Key(fqn("foo"))).asserting(_._1.map(b => reducesTo(b.semValue)) shouldBe Some(Some("b")))
+    fact(NativeBinding.Key(fqn("foo"))).asserting(_._1.map(b => b.semValue.flatMap(reducesTo)) shouldBe Some(Some("b")))
   }
 
   it should "contribute None for a name absent from the compiler pool" in {

--- a/lang/test/src/com/vanillasource/eliot/eliotc/monomorphize/processor/MatchNativesProcessorTest.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/monomorphize/processor/MatchNativesProcessorTest.scala
@@ -89,6 +89,6 @@ class MatchNativesProcessorTest extends ProcessorTest(LangProcessors()*) {
   private def groundViaQuote(source: String, name: String): IO[Option[Either[String, GroundValue]]] = {
     val key = NativeBinding.Key(ValueFQN(testModuleName, default(name)))
     runGenerator(source, key, matchImports)
-      .map(_._2.get(key).map(fact => Quoter.quote(0, fact.asInstanceOf[NativeBinding].semValue, MetaStore.empty)))
+      .map(_._2.get(key).flatMap(fact => fact.asInstanceOf[NativeBinding].semValue.map(Quoter.quote(0, _, MetaStore.empty))))
   }
 }


### PR DESCRIPTION
Make the evaluator-facing NativeBinding fact total: instead of declining
(aborting) when no supplier binds a name, BindingMergerProcessor now
publishes a NativeBinding carrying semValue = None. This is step 1 of
docs/retire-optional-fact-reads.md — a total fact removes the optional read
and, since a key with no cache entry always reads as "changed", the
cache-poison edge a decline leaves behind.

- NativeBinding.semValue becomes Option[SemValue]; None is a domain answer
  ("no binding; evaluation stays stuck at the use site"), not a missing fact.
- BindingMergerProcessor: the final `case None => abort` becomes a None
  payload, making the output total (the inputs were already total).
- Bucket-1 readers (MonomorphicTypeCheckProcessor,
  CompilerMonomorphicTypeCheckProcessor) switch from getFactIfProduced to
  getFactOrAbort and inspect the payload.
- Bucket-3 cyclic-walk readers (BindingClosure, ReducedBindingClosure) stay
  tolerant (their ancestor guard handles the possibly-cyclic walk) and only
  adapt to the new Option payload.
- Tests reading .semValue updated accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TZEBtVJhYyD9WZx6xYHjid