### PR TITLE
Totalize UnifiedModuleNames + ModuleAbilities (retire-optional-fact-reads step 2, module membership)

### DIFF
--- a/docs/retire-optional-fact-reads.md
+++ b/docs/retire-optional-fact-reads.md
@@ -1,11 +1,26 @@
 # Retiring the Optional Fact Read (`getFactIfProduced`)
 
-Status: **PLAN (2026-08-02); step 1 landed.** Written against the current tree. §6.1 (the `NativeBinding`
-totalization) is done: the fact now carries `semValue: Option[SemValue]`, `BindingMergerProcessor` publishes a
-`None` payload instead of aborting, and the Bucket-1 readers (`MonomorphicTypeCheckProcessor`,
-`CompilerMonomorphicTypeCheckProcessor`) read it with `getFactOrAbort`. The Bucket-3 cyclic-walk readers
-(`BindingClosure`, `ReducedBindingClosure`) stay tolerant and only inspect the new `Option` payload. The rest is
-still open.
+Status: **PLAN (2026-08-02); steps 1 and the module-membership half of step 2 landed.** Written against the current
+tree. §6.1 (the `NativeBinding` totalization) is done: the fact now carries `semValue: Option[SemValue]`,
+`BindingMergerProcessor` publishes a `None` payload instead of aborting, and the Bucket-1 readers
+(`MonomorphicTypeCheckProcessor`, `CompilerMonomorphicTypeCheckProcessor`) read it with `getFactOrAbort`. The
+Bucket-3 cyclic-walk readers (`BindingClosure`, `ReducedBindingClosure`) stay tolerant and only inspect the new
+`Option` payload.
+
+§6.2's **module-membership / pool-routing** fact is now also total: `UnifiedModuleNames` carries `present: Boolean`
+and `UnifiedModuleNamesProcessor` answers with an empty, `present = false` fact for a module that resolves in no
+mount of the pool (reading `PathScan` tolerantly) instead of declining — the `PathScan` producer still owns the
+runtime "Could not find path" error, so the decline's error is not suppressed, only its cache-poison edge is
+removed. Its immediate downstream `ModuleAbilities` is total for free (its producer already read `UnifiedModuleNames`
+with `getFactOrAbort`). Every reader now uses `getFactOrAbort`: the membership probes (`DeclaringPool`,
+`CompilerMonomorphicTypeCheckProcessor`, `CompilerNativesProcessor`, `RefinementChannelProcessor`,
+`SaturatedValueProcessor`) read `names.contains(...)`, which is `false` for an absent module; the two readers that
+must tell absent from present-but-empty (`ModuleValueProcessor` import resolution, `JvmProgramGenerator`'s
+entry-point pre-flight) inspect `present`; the two `ModuleAbilities` probes (`ImplementationMarkerUtils`,
+`AbilityImplementationProcessor`) read the structured lists directly. Verified byte-identical example output
+(`HelloWorld`/`Effects`/`DischargeDemo`/`AbilityDerive`/`Arithmetic`). What remains open in Bucket 1 is the
+**ability-resolution** probes that read *other* facts (`AbilityResolver`, `AbilityMatcher`,
+`AbilityImplementationCheckProcessor`, `ModuleAbilityOverlapCheckProcessor`), plus Bucket 2 and Bucket 3.
 
 ## 1. The problem, restated
 
@@ -149,7 +164,8 @@ value, not merely a drillable one; decline-caching is the safety net for the gen
 
 1. **Finish the natives** (`NativeBinding` total + its ~5 readers). Smallest, self-contained, and the worked
    example for the rest. Measure warm-build regeneration count before/after. **✓ Done.**
-2. **Bucket 1 remainder** (module membership, ability lookups). Biggest cache win.
+2. **Bucket 1 remainder** (module membership, ability lookups). Biggest cache win. **✓ Module membership done**
+   (`UnifiedModuleNames` + `ModuleAbilities` total); ability-resolution probes over other facts still open.
 3. **Bucket 2.**
 4. **Bucket 3 rename** (cheap; makes intent explicit and prevents backsliding).
 5. **§5 decline-caching** for the residual.

--- a/jvm/src/com/vanillasource/eliot/eliotc/jvm/jargen/JvmProgramGenerator.scala
+++ b/jvm/src/com/vanillasource/eliot/eliotc/jvm/jargen/JvmProgramGenerator.scala
@@ -61,12 +61,12 @@ class JvmProgramGenerator(targetDir: Path) extends SingleFactProcessor[GenerateE
     * missing-instance errors already point at the user's own source.
     */
   private def validateMainExists(vfqn: ValueFQN): CompilerIO[Unit] =
-    getFactIfProduced(UnifiedModuleNames.Key(vfqn.moduleName)).flatMap {
-      case None                                            =>
+    getFactOrAbort(UnifiedModuleNames.Key(vfqn.moduleName)).flatMap {
+      case names if !names.present                   =>
         failGlobally(s"Module '${vfqn.moduleName.show}' was not found on the source paths.")
-      case Some(names) if !names.names.contains(vfqn.name) =>
+      case names if !names.names.contains(vfqn.name) =>
         failGlobally(s"Module '${vfqn.moduleName.show}' has no '${vfqn.name.name}' value to run.")
-      case _                                               => ().pure[CompilerIO]
+      case _                                         => ().pure[CompilerIO]
     }
 
   private def failGlobally(message: String): CompilerIO[Unit] =

--- a/lang/src/com/vanillasource/eliot/eliotc/ability/processor/AbilityImplementationProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/ability/processor/AbilityImplementationProcessor.scala
@@ -135,10 +135,8 @@ class AbilityImplementationProcessor extends SingleKeyTypeProcessor[AbilityImple
       abilityLocalName: String,
       platform: Platform
   ): CompilerIO[Seq[ValueFQN]] =
-    getFactIfProduced(ModuleAbilities.Key(moduleName, platform)).map {
-      case None        => Seq.empty
-      case Some(impls) => impls.namedImplementationMethodsOf(abilityLocalName, functionName)
-    }
+    getFactOrAbort(ModuleAbilities.Key(moduleName, platform))
+      .map(_.namedImplementationMethodsOf(abilityLocalName, functionName))
 
   private def verifyImplementation(
       vfqn: ValueFQN,

--- a/lang/src/com/vanillasource/eliot/eliotc/ability/util/ImplementationMarkerUtils.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/ability/util/ImplementationMarkerUtils.scala
@@ -96,7 +96,7 @@ object ImplementationMarkerUtils {
       pattern: String,
       platform: Platform
   ): CompilerIO[Option[ValueFQN]] =
-    getFactIfProduced(ModuleAbilities.Key(moduleName, platform)).map(_.flatMap(_.markerOf(abilityName, pattern)))
+    getFactOrAbort(ModuleAbilities.Key(moduleName, platform)).map(_.markerOf(abilityName, pattern))
 
   private def firstArgTypeConstructorName(signature: Expression): Option[String] = {
     import Expression.*

--- a/lang/src/com/vanillasource/eliot/eliotc/module/fact/UnifiedModuleNames.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/module/fact/UnifiedModuleNames.scala
@@ -5,9 +5,24 @@ import com.vanillasource.eliot.eliotc.module.fact.QualifiedName
 import com.vanillasource.eliot.eliotc.platform.Platform
 import com.vanillasource.eliot.eliotc.processor.{CompilerFact, CompilerFactKey}
 
+/** The flattened name set of a module in one platform pool.
+  *
+  * The fact is *total*: [[com.vanillasource.eliot.eliotc.module.processor.UnifiedModuleNamesProcessor]] answers with an
+  * empty, `present = false` fact for a module that resolves in no mount of the pool rather than declining, so readers
+  * request it with `getFactOrAbort` and inspect the payload. A membership probe reads `names.contains(...)`, which is
+  * correctly `false` for an absent module; the two readers that must tell an *absent* module apart from a *present but
+  * empty* one (import resolution, the jvm entry-point pre-flight) inspect [[present]]. Keeping the fact total removes the
+  * cache-poison edge a decline would leave behind (an absent module recomputes to the same equality-stable empty value,
+  * so its readers stop regenerating every warm build — see `docs/retire-optional-fact-reads.md`).
+  *
+  * @param present
+  *   `true` when the module resolves in at least one mount of [[platform]]'s pool; `false` for the totalized absent case
+  *   (which always carries an empty [[names]]).
+  */
 case class UnifiedModuleNames(
     moduleName: ModuleName,
     names: Map[QualifiedName, Visibility],
+    present: Boolean,
     platform: Platform = Platform.Runtime
 ) extends CompilerFact {
   override def key(): CompilerFactKey[UnifiedModuleNames] = UnifiedModuleNames.Key(moduleName, platform)

--- a/lang/src/com/vanillasource/eliot/eliotc/module/processor/ModuleValueProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/module/processor/ModuleValueProcessor.scala
@@ -73,24 +73,21 @@ class ModuleValueProcessor(systemModules: Seq[ModuleName] = defaultSystemModules
   ): CompilerIO[ImportResult] =
     systemModules.foldLeftM(ImportResult(Map.empty, Map.empty)) { (acc, m) =>
       for {
-        maybeModuleNames <- getFactIfProduced(UnifiedModuleNames.Key(m.value, platform))
-        result           <- maybeModuleNames match {
-                              case Some(moduleNames) =>
-                                val free = (name: QualifiedName) =>
-                                  !takenNames.contains(name) && !acc.dictionary.contains(name) && !acc.privateNames.contains(name)
-                                ImportResult(
-                                  acc.dictionary ++ moduleNames.names.collect {
-                                    case (name, Visibility.Public) if free(name) =>
-                                      (name, ValueFQN(moduleNames.moduleName, name))
-                                  },
-                                  acc.privateNames ++ moduleNames.names.collect {
-                                    case (name, Visibility.Private) if free(name) =>
-                                      (name, ValueFQN(moduleNames.moduleName, name))
-                                  }
-                                ).pure[CompilerIO]
-                              case None              =>
-                                compilerError(m.as(s"Could not find imported module: `${m.value.show}`")).as(acc)
-                            }
+        moduleNames <- getFactOrAbort(UnifiedModuleNames.Key(m.value, platform))
+        result      <- if (moduleNames.present) {
+                         val free = (name: QualifiedName) =>
+                           !takenNames.contains(name) && !acc.dictionary.contains(name) && !acc.privateNames.contains(name)
+                         ImportResult(
+                           acc.dictionary ++ moduleNames.names.collect {
+                             case (name, Visibility.Public) if free(name) =>
+                               (name, ValueFQN(moduleNames.moduleName, name))
+                           },
+                           acc.privateNames ++ moduleNames.names.collect {
+                             case (name, Visibility.Private) if free(name) =>
+                               (name, ValueFQN(moduleNames.moduleName, name))
+                           }
+                         ).pure[CompilerIO]
+                       } else compilerError(m.as(s"Could not find imported module: `${m.value.show}`")).as(acc)
       } yield result
     }
 
@@ -110,44 +107,41 @@ class ModuleValueProcessor(systemModules: Seq[ModuleName] = defaultSystemModules
       platform: Platform
   ): CompilerIO[ImportResult] =
     for {
-      maybeModuleNames <- getFactIfProduced(UnifiedModuleNames.Key(module.value, platform))
-      result           <- maybeModuleNames match {
-                            case Some(moduleNames) =>
-                              val publicNames       = moduleNames.names.collect { case (name, Visibility.Public) =>
-                                name
-                              }.toSet
-                              val privateNameSet    = moduleNames.names.collect { case (name, Visibility.Private) =>
-                                name
-                              }.toSet
-                              val shadowingLocal    = publicNames.intersect(localNames)
-                              val shadowingImported = publicNames.intersect(accumulated.dictionary.keySet)
+      moduleNames <- getFactOrAbort(UnifiedModuleNames.Key(module.value, platform))
+      result      <- if (moduleNames.present) {
+                       val publicNames       = moduleNames.names.collect { case (name, Visibility.Public) =>
+                         name
+                       }.toSet
+                       val privateNameSet    = moduleNames.names.collect { case (name, Visibility.Private) =>
+                         name
+                       }.toSet
+                       val shadowingLocal    = publicNames.intersect(localNames)
+                       val shadowingImported = publicNames.intersect(accumulated.dictionary.keySet)
 
-                              if (shadowingLocal.nonEmpty) {
-                                compilerError(
-                                  module.as(
-                                    s"Imported names shadow local names: ${shadowingLocal.toSeq.map(_.show).mkString(", ")}"
-                                  )
-                                )
-                                  .as(accumulated)
-                              } else if (shadowingImported.nonEmpty) {
-                                compilerError(
-                                  module.as(
-                                    s"Imported names shadow other imported names: ${shadowingImported.flatMap(accumulated.dictionary.get).mkString(", ")}"
-                                  )
-                                ).as(accumulated)
-                              } else {
-                                ImportResult(
-                                  accumulated.dictionary ++ publicNames
-                                    .map(name => (name, ValueFQN(moduleNames.moduleName, name)))
-                                    .toMap,
-                                  accumulated.privateNames ++ privateNameSet
-                                    .map(name => (name, ValueFQN(moduleNames.moduleName, name)))
-                                    .toMap
-                                ).pure[CompilerIO]
-                              }
-                            case None              =>
-                              compilerError(module.as(s"Could not find imported module: `${module.value.show}`"))
-                                .as(accumulated)
-                          }
+                       if (shadowingLocal.nonEmpty) {
+                         compilerError(
+                           module.as(
+                             s"Imported names shadow local names: ${shadowingLocal.toSeq.map(_.show).mkString(", ")}"
+                           )
+                         )
+                           .as(accumulated)
+                       } else if (shadowingImported.nonEmpty) {
+                         compilerError(
+                           module.as(
+                             s"Imported names shadow other imported names: ${shadowingImported.flatMap(accumulated.dictionary.get).mkString(", ")}"
+                           )
+                         ).as(accumulated)
+                       } else {
+                         ImportResult(
+                           accumulated.dictionary ++ publicNames
+                             .map(name => (name, ValueFQN(moduleNames.moduleName, name)))
+                             .toMap,
+                           accumulated.privateNames ++ privateNameSet
+                             .map(name => (name, ValueFQN(moduleNames.moduleName, name)))
+                             .toMap
+                         ).pure[CompilerIO]
+                       }
+                     } else compilerError(module.as(s"Could not find imported module: `${module.value.show}`"))
+                       .as(accumulated)
     } yield result
 }

--- a/lang/src/com/vanillasource/eliot/eliotc/module/processor/UnifiedModuleNamesProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/module/processor/UnifiedModuleNamesProcessor.scala
@@ -8,9 +8,20 @@ import com.vanillasource.eliot.eliotc.source.scan.PathScan
 
 class UnifiedModuleNamesProcessor extends SingleFactProcessor[UnifiedModuleNames.Key] {
 
+  // Total: a module that resolves in no mount of the pool has no `PathScan`, so read it tolerantly and answer with an
+  // empty, `present = false` fact rather than declining. The `PathScan` producer still owns the runtime-pool "Could not
+  // find path" error (and the compiler-pool silent decline), so tolerating its absence here does not suppress it — it
+  // only stops this fact leaving a cache-poison edge. Readers that must distinguish absent from present-but-empty
+  // inspect `present`; membership probes read `names` and see the empty map either way.
   override protected def generateSingleFact(key: UnifiedModuleNames.Key): CompilerIO[UnifiedModuleNames] =
-    for {
-      pathScan <- getFactOrAbort(PathScan.Key(key.moduleName.toPath, key.platform))
-      allNames <- pathScan.files.traverse(uri => getFactOrAbort(ModuleNames.Key(uri)))
-    } yield UnifiedModuleNames(key.moduleName, allNames.flatMap(_.names.value).toMap, key.platform)
+    getFactIfProduced(PathScan.Key(key.moduleName.toPath, key.platform)).flatMap {
+      case None           =>
+        UnifiedModuleNames(key.moduleName, Map.empty, present = false, key.platform).pure[CompilerIO]
+      case Some(pathScan) =>
+        pathScan.files
+          .traverse(uri => getFactOrAbort(ModuleNames.Key(uri)))
+          .map(allNames =>
+            UnifiedModuleNames(key.moduleName, allNames.flatMap(_.names.value).toMap, present = true, key.platform)
+          )
+    }
 }

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/channel/RefinementChannelProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/channel/RefinementChannelProcessor.scala
@@ -187,8 +187,8 @@ class RefinementChannelProcessor
       calleeTypeArgs: Seq[GroundValue],
       argMetas: Seq[Option[GroundValue]]
   ): CompilerIO[Option[GroundValue]] =
-    getFactIfProduced(UnifiedModuleNames.Key(callee.moduleName, Platform.Compiler)).flatMap { namesOpt =>
-      if (!namesOpt.exists(_.names.contains(QualifiedName(callee.name.name, Qualifier.Meta))))
+    getFactOrAbort(UnifiedModuleNames.Key(callee.moduleName, Platform.Compiler)).flatMap { names =>
+      if (!names.names.contains(QualifiedName(callee.name.name, Qualifier.Meta)))
         none[GroundValue].pure[CompilerIO]
       else
         for {
@@ -221,8 +221,8 @@ class RefinementChannelProcessor
   private def metaTypeOf(baseType: GroundValue): CompilerIO[GroundValue] = baseType match {
     case GroundValue.Structure(fqn, _, _) =>
       val metaName = QualifiedName(fqn.name.name + MetaConstructorDesugarer.metaTypeSuffix, Qualifier.Type)
-      getFactIfProduced(UnifiedModuleNames.Key(fqn.moduleName, Platform.Compiler)).map { namesOpt =>
-        if (namesOpt.exists(_.names.contains(metaName)))
+      getFactOrAbort(UnifiedModuleNames.Key(fqn.moduleName, Platform.Compiler)).map { names =>
+        if (names.names.contains(metaName))
           GroundValue.Structure(ValueFQN(fqn.moduleName, metaName), Seq.empty, GroundValue.Type)
         else unitType
       }
@@ -275,8 +275,8 @@ class RefinementChannelProcessor
     * [[whereCompanionName]] in the compiler pool (where [[MetaWhereDesugarer]] emits the `^Where` companion).
     */
   private def hasWhereCompanion(callee: ValueFQN): CompilerIO[Boolean] =
-    getFactIfProduced(UnifiedModuleNames.Key(callee.moduleName, Platform.Compiler))
-      .map(_.exists(_.names.contains(whereCompanionName(callee))))
+    getFactOrAbort(UnifiedModuleNames.Key(callee.moduleName, Platform.Compiler))
+      .map(_.names.contains(whereCompanionName(callee)))
 
   private def rejectWhereAsValueIfBearing(node: Sourced[MonomorphicExpression], callee: ValueFQN): CompilerIO[Unit] =
     hasWhereCompanion(callee).ifM(rejectWhereAsValue(node, callee), ().pure[CompilerIO])

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerMonomorphicTypeCheckProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerMonomorphicTypeCheckProcessor.scala
@@ -81,7 +81,7 @@ class CompilerMonomorphicTypeCheckProcessor()
     * direct value/binding request would raise.
     */
   private def inRuntimePool(vfqn: ValueFQN): CompilerIO[Boolean] =
-    getFactIfProduced(UnifiedModuleNames.Key(vfqn.moduleName, Platform.Runtime)).map(_.exists(_.names.contains(vfqn.name)))
+    getFactOrAbort(UnifiedModuleNames.Key(vfqn.moduleName, Platform.Runtime)).map(_.names.contains(vfqn.name))
 
   override protected def generateFromKeyAndFact(
       key: CompilerMonomorphicValue.Key,
@@ -173,8 +173,8 @@ class CompilerMonomorphicTypeCheckProcessor()
     * companion ([[MetaWhereDesugarer.whereSuffix]] in the [[Qualifier.Meta]] namespace) in the compiler pool.
     */
   private def hasWhereCompanion(callee: ValueFQN): CompilerIO[Boolean] =
-    getFactIfProduced(UnifiedModuleNames.Key(callee.moduleName, Platform.Compiler))
-      .map(_.exists(_.names.contains(QualifiedName(callee.name.name + MetaWhereDesugarer.whereSuffix, Qualifier.Meta))))
+    getFactOrAbort(UnifiedModuleNames.Key(callee.moduleName, Platform.Compiler))
+      .map(_.names.contains(QualifiedName(callee.name.name + MetaWhereDesugarer.whereSuffix, Qualifier.Meta)))
 
   /** Resolve an ability in the **compiler** pool: a compiler-track value is entirely compile-time, so all of its
     * ability references belong to the compiler platform.

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerNativesProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/CompilerNativesProcessor.scala
@@ -60,7 +60,7 @@ class CompilerNativesProcessor extends BodyContributorProcessor(ContributedBindi
     * error a direct value request would.
     */
   private def inCompilerPool(vfqn: ValueFQN): CompilerIO[Boolean] =
-    getFactIfProduced(UnifiedModuleNames.Key(vfqn.moduleName, Platform.Compiler)).map(_.exists(_.names.contains(vfqn.name)))
+    getFactOrAbort(UnifiedModuleNames.Key(vfqn.moduleName, Platform.Compiler)).map(_.names.contains(vfqn.name))
 
   /** A **compile-time** value — one the compiler layer defines (concrete here) but the runtime pool leaves abstract, e.g.
     * the compiler-layer effect-carrier overlays that reduce an inline `if..else..raise` guard (the `Effect`/`Abort`
@@ -133,8 +133,8 @@ class CompilerNativesProcessor extends BodyContributorProcessor(ContributedBindi
   private def runtimeConcrete(vfqn: ValueFQN): CompilerIO[Boolean] =
     if (isRefinementArtifact(vfqn)) false.pure[CompilerIO]
     else
-      getFactIfProduced(UnifiedModuleNames.Key(vfqn.moduleName, Platform.Runtime))
-        .map(_.exists(_.names.contains(vfqn.name)))
+      getFactOrAbort(UnifiedModuleNames.Key(vfqn.moduleName, Platform.Runtime))
+        .map(_.names.contains(vfqn.name))
         .ifM(
           getFactIfProduced(SaturatedValue.Key(vfqn, Platform.Runtime)).map(_.exists(_.value.runtime.isDefined)),
           false.pure[CompilerIO]

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/DeclaringPool.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/DeclaringPool.scala
@@ -34,5 +34,5 @@ object DeclaringPool {
     )
 
   private def isMember(vfqn: ValueFQN, platform: Platform): CompilerIO[Boolean] =
-    getFactIfProduced(UnifiedModuleNames.Key(vfqn.moduleName, platform)).map(_.exists(_.names.contains(vfqn.name)))
+    getFactOrAbort(UnifiedModuleNames.Key(vfqn.moduleName, platform)).map(_.names.contains(vfqn.name))
 }

--- a/lang/src/com/vanillasource/eliot/eliotc/saturate/processor/SaturatedValueProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/saturate/processor/SaturatedValueProcessor.scala
@@ -346,8 +346,8 @@ class SaturatedValueProcessor
     */
   private def recordPlanFor(module: ModuleName, typeName: String)(using platform: Platform): CompilerIO[Option[TypePlan]] = {
     val ctorName = QualifiedName(typeName, Qualifier.Default)
-    getFactIfProduced(UnifiedModuleNames.Key(module, platform)).flatMap {
-      case Some(names) if names.names.contains(ctorName) =>
+    getFactOrAbort(UnifiedModuleNames.Key(module, platform)).flatMap {
+      case names if names.names.contains(ctorName) =>
         getFactIfProduced(OperatorResolvedValue.Key(ValueFQN(module, ctorName), platform)).flatMap {
           case Some(ctor) if isRecordConstructor(ctor, typeName) =>
             SignatureView.of(signatureOf(ctor)).parameters.map(_.value).traverse(fieldContribution).map { fields =>
@@ -356,7 +356,7 @@ class SaturatedValueProcessor
             }
           case _                                                 => none[TypePlan].pure[CompilerIO]
         }
-      case _                                             => none[TypePlan].pure[CompilerIO]
+      case _                                       => none[TypePlan].pure[CompilerIO]
     }
   }
 

--- a/lang/test/src/com/vanillasource/eliot/eliotc/namedvalues/NamedValuesIndexProcessorTest.scala
+++ b/lang/test/src/com/vanillasource/eliot/eliotc/namedvalues/NamedValuesIndexProcessorTest.scala
@@ -17,7 +17,7 @@ class NamedValuesIndexProcessorTest extends ProcessorTest(NamedValuesIndexProces
   private def specFqn(module: ModuleName): ValueFQN = ValueFQN(module, QualifiedName("spec", Qualifier.Default))
 
   private def unified(module: ModuleName, names: (QualifiedName, Visibility)*): UnifiedModuleNames =
-    UnifiedModuleNames(module, names.toMap, Platform.Runtime)
+    UnifiedModuleNames(module, names.toMap, present = true, Platform.Runtime)
 
   private def publicDefault(name: String): (QualifiedName, Visibility) =
     QualifiedName(name, Qualifier.Default) -> Visibility.Public


### PR DESCRIPTION
Continues docs/retire-optional-fact-reads.md. Step 1 totalized NativeBinding;
this lands the module-membership / pool-routing half of Bucket 1.

UnifiedModuleNames now carries `present: Boolean` and its processor answers with
an empty, `present = false` fact for a module that resolves in no mount of the
pool (reading PathScan tolerantly) instead of declining. The PathScan producer
still owns the runtime "Could not find path" error and the compiler-pool silent
decline, so tolerating its absence here suppresses no error — it only removes the
cache-poison edge the decline left behind. On a warm build the absent module now
recomputes to the same equality-stable empty value, so its readers (the
monomorphize layer) stop regenerating every build.

Its immediate downstream ModuleAbilities is total for free (its producer already
read UnifiedModuleNames with getFactOrAbort). Every reader moves to
getFactOrAbort: the membership probes (DeclaringPool,
CompilerMonomorphicTypeCheckProcessor, CompilerNativesProcessor,
RefinementChannelProcessor, SaturatedValueProcessor) read names.contains(...),
which is false for an absent module; the two readers that must tell absent from
present-but-empty (ModuleValueProcessor import resolution, JvmProgramGenerator's
entry-point pre-flight) inspect `present`; the two ModuleAbilities probes
(ImplementationMarkerUtils, AbilityImplementationProcessor) read the structured
lists directly.

Verified: ./mill __.test green across all modules, and byte-identical example
output (HelloWorld/Effects/DischargeDemo/AbilityDerive/Arithmetic) cold vs the
prior tree, confirming totalizing did not change codegen.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHgaqzkzzrWNMZLVQBGGBA