### PR TITLE
Remeasure the warm build after the totalization, and sharpen the fix

### DIFF
--- a/docs/incremental-compilation.md
+++ b/docs/incremental-compilation.md
@@ -1,10 +1,13 @@
 # Incremental Compilation: Why a Warm Build Still Computes
 
-Status: **PARTLY FIXED (2026-08-03).** §3.3 (the decline-poison) landed on 2026-08-02 as the `NativeBinding` /
-`UnifiedModuleNames` totalization (`docs/retire-optional-fact-reads.md` §6.1–6.2). Re-measured, a warm build now
-regenerates **366 facts, down from 2129** — but it is still not leaf-only, and the dominant residual cost, the
-`MonomorphicValue` re-check cascade, survives. §8 below records the fresh measurement and the sharpened next step.
-The original diagnosis (§§1–7) is written against `7588845b` and still holds.
+Status: **WARM BUILD IS NOW LEAF-ONLY (2026-08-03).** Two fixes landed. §3.3 (the decline-poison) landed
+2026-08-02 as the `NativeBinding` / `UnifiedModuleNames` totalization (`docs/retire-optional-fact-reads.md`
+§6.1–6.2), taking a warm build from 2129 → 366 regenerations. §3.2 (the edge-less contributors) then landed as
+Step 2, the `UpToDate` anchor on `StdlibNativesProcessor` / `DataTypeNativesProcessor` / `MatchNativesProcessor`,
+taking it 366 → **252 — world leaves only, with every native contributor and `MonomorphicTypeCheckProcessor` at 0
+calls**. What remains (§3.1: ~18 value-less `NativeBinding`/`ContributedBinding` top-level demands) needs Step 1
+(the `FactCodec`), is cheap, and is the only thing between here and the load floor (§7). §8 records both
+measurements. The original diagnosis (§§1–7) is written against `7588845b` and still holds.
 
 The engine works as designed; what follows is not a bug *in* the incremental algorithm but a set of fact types
 and outcomes the algorithm was never told the truth about.
@@ -296,12 +299,12 @@ not serialize, and it read nothing, so it has neither a comparable value nor edg
 as "changed" every run and poisons the ~4 `MonomorphicValue`s that transitively depend on it, forcing the 214 ms
 re-typecheck. It is the same defect as the 92 above, one step worse.
 
-### The fix: land Step 2 (the `UpToDate` anchor), for real this time
+### The fix: Step 2 (the `UpToDate` anchor) — LANDED 2026-08-03
 
-This is exactly §6 Step 2, and the measurement now proves it fixes *both* residual bugs in one move — the earlier
-revert bundled it with the cache-size Step-1 attempt (§5), so it never landed on its own.
+This is exactly §6 Step 2, and the measurement proved it fixes *both* residual bugs in one move — the earlier
+revert had bundled it with the cache-size Step-1 attempt (§5), so it never landed on its own.
 
-Give every input-less contributor the `UpToDate` edge, uniformly at the top of the generation so *every* return
+Gave every input-less contributor the `UpToDate` edge, uniformly at the top of the generation so *every* return
 path (hit, miss, and abort-guarded) is covered — the same two lines `SystemNativesProcessor` already carries:
 
 ```scala
@@ -319,20 +322,29 @@ After the anchor, each such `ContributedBinding` becomes a non-leaf whose one ed
 constant: `resolve` validates it structurally and **accepts it from cache** instead of regenerating, and the
 value-less one is drilled (not re-typechecked), which removes the `MonomorphicValue` cascade.
 
-**Projected result:** 366 → ~269 regenerations (92 `ContributedBinding` + the 4 `MonomorphicValue` gone), with
-`MonomorphicTypeCheckProcessor` at **0 calls** — the 214 ms, 22.7 % line disappears. The remaining ~18 value-less
-`NativeBinding`/`ContributedBinding` top-level demands are §3.1 and need Step 1 (the `FactCodec`/`OpaqueCodec`);
-several of *those* are likely only demanded because the 4 `MonomorphicValue`s currently regenerate, so re-measure
-after the anchor before sizing Step 1.
+**Measured result** (same `DischargeDemo` warm build): **366 → 252 regenerations**, and the `--statistics` roster
+shows **only `FileStatProcessor` (249) and `OutputFileStatProcessor` (1) active** — every native contributor,
+`BindingMergerProcessor`, and both `MonomorphicTypeCheckProcessor`s at **0 calls**. Wall time 944 ms → 724 ms
+(processor time 355 ms → 112 ms, almost all of it the 249 unavoidable file stats). 252 is the leaf floor: 249
+`FileStat` + `OutputFileStat` + `UpToDate` + the synthetic-main `SourceContent`. The projected ~18 value-less
+`NativeBinding` top-level demands from §3.1 turned out to vanish too — they were only demanded *because* the 4
+`MonomorphicValue`s regenerated; with the cascade gone they are validated as drilled dependencies, not top-level
+demands. Step 1 (the `FactCodec`) is now only needed for the load floor (§7), not for regeneration count.
 
-**Risk & verification.** The anchor only *widens* what is accepted from cache, so the risk is under-invalidation.
-Guard it exactly as §6 Step 6 says: `./mill __.test`; the fast example sweep + byte-identical cold-vs-warm jar
-(now runnable since jar output is deterministic); a touch-one-source test confirming a bounded, correct subset
-still recompiles; and an assertion on the metric itself — a warm run over an unchanged tree regenerates only world
-leaves (no `ContributedBinding`, no `MonomorphicValue`). The `UpToDate` read stays `getFactIfProduced` (tolerant):
-a minimal test bundle without `UpToDateProcessor` loses incrementality here but never fails.
+**Verification run.** `./mill __.test` green. Byte-identical cold-vs-warm jar (`cmp` clean; the warm jar runs and
+prints the right output) — the anchor only *widens* cache acceptance, and this is the under-invalidation guard.
+Touch-one-source test: editing `demo(true)` → `demo(false)` moved the warm count 252 → 357 (a bounded subset, not
+the full 2129) and the output correctly flipped to `discharged: OFF`, then back on restore — so a real change
+still propagates. The `UpToDate` read stays `getFactIfProduced` (tolerant): a minimal test bundle without
+`UpToDateProcessor` loses incrementality here but never fails.
+
+**Still worth adding** (§6 Step 6): a standing metric assertion — a warm run over an unchanged tree regenerates
+only world leaves — as an integration test over a real two-run cache, so a future contributor that forgets the
+anchor is caught automatically rather than by re-running the manual reproduction below. It guards *any* contributor,
+not just these three, and pairs with Step 5's permanent DEBUG trace.
 
 Reproduction: enable `<Logger name="com.vanillasource.eliot.eliotc.compiler.IncrementalFactGenerator"
-level="debug"/>`, build twice, read the `Incremental run: regenerated N` line (the per-reason breakdown above came
+level="debug"/>`, build twice **with identical flags** (a differing `--statistics` changes the config fingerprint
+and discards the cache), and read the `Incremental run: regenerated N` line. The per-reason breakdown above came
 from temporary traces in `regenerate`/`computeUnchanged`, reverted — Step 5's permanent DEBUG trace would make it
-standing).
+standing.

--- a/docs/incremental-compilation.md
+++ b/docs/incremental-compilation.md
@@ -1,8 +1,10 @@
 # Incremental Compilation: Why a Warm Build Still Computes
 
-Status: **DIAGNOSED (2026-07-31); fix designed, none of it landed.** The three invalidation sources below are
-measured and reproducible. Step 2 of the plan was written and validated, then reverted together with a Step 1
-attempt that failed on cache size (§5). Everything here is written against `7588845b`.
+Status: **PARTLY FIXED (2026-08-03).** §3.3 (the decline-poison) landed on 2026-08-02 as the `NativeBinding` /
+`UnifiedModuleNames` totalization (`docs/retire-optional-fact-reads.md` §6.1–6.2). Re-measured, a warm build now
+regenerates **366 facts, down from 2129** — but it is still not leaf-only, and the dominant residual cost, the
+`MonomorphicValue` re-check cascade, survives. §8 below records the fresh measurement and the sharpened next step.
+The original diagnosis (§§1–7) is written against `7588845b` and still holds.
 
 The engine works as designed; what follows is not a bug *in* the incremental algorithm but a set of fact types
 and outcomes the algorithm was never told the truth about.
@@ -256,3 +258,81 @@ facts against today's 2129, with no processor active but `FileStatProcessor`.
   fingerprints, which never existed. They are documented in §1 here; the scaladoc reference should be corrected.
 - **Two wrong class docs**: `MonomorphicValue` and `IncrementalFactGenerator` both claim the monomorphize layer
   cannot be persisted (§4).
+
+## 8. Remeasurement after the totalization (2026-08-03)
+
+The `NativeBinding` / `UnifiedModuleNames` / `ModuleAbilities` totalization landed 2026-08-02 and removed the
+§3.3 decline-poison. Re-measured on `examples.run jvm exe-jar -m DischargeDemo`, warm build immediately after an
+identical build, instrumenting `regenerate` (why each fact re-ran) and `computeUnchanged` (which dependency was
+judged changed):
+
+```
+Before (7588845b): regenerated 2129;  4385 ms;  MonomorphicTypeCheck 1341 ms (51.6%), 251 calls
+After  (this tree): regenerated  366;   944 ms;  MonomorphicTypeCheck  214 ms (22.7%),   4 calls
+```
+
+The 366 regenerations break down by *why* they re-ran, not just by type:
+
+| count | reason              | fact type          | verdict                                             |
+| ----- | ------------------- | ------------------ | --------------------------------------------------- |
+| 249   | value-leaf          | `FileStat`         | **correct** — world leaf                            |
+| 1     | value-leaf          | `OutputFileStat`   | **correct** — world leaf                            |
+| 1     | value-leaf          | `UpToDate`         | **correct** — the anchor constant                   |
+| 1     | value-leaf          | `SourceContent`    | correct enough — synthetic-main source, empty deps  |
+| **92**| **value-leaf**      | **`ContributedBinding`** | **BUG — §3.2**: edge-less, so read as a leaf   |
+| **4** | **dep-changed**     | **`MonomorphicValue`**   | **BUG — the §3.4 cascade, 214 ms**             |
+| 14    | valueless-topdemand | `NativeBinding`    | §3.1 residue — value-less, demanded top-level       |
+| 3+1   | valueless           | `ContributedBinding`     | §3.1 residue                                   |
+
+"value-leaf" = the prior entry has a stored value but an **empty** `directDeps`, so `resolve` treats it as a
+world leaf and regenerates it unconditionally. That is the whole of the 92-fact bug: `StdlibNativesProcessor`
+answers a name from a static `Map` (hit path) or `None` (miss path) **without reading any fact**, so its
+`ContributedBinding`s carry no edges and are indistinguishable from a `FileStat`. `SystemNativesProcessor` already
+avoids this by depending on `UpToDate.Key()`; the other contributors never got the anchor.
+
+**Confirmed cascade.** Instrumenting the single changed-dependency verdict shows exactly **one**
+`edgeless-unstorable ContributedBinding` — a value-less *and* edge-less contribution (its `SemValue` closure will
+not serialize, and it read nothing, so it has neither a comparable value nor edges to drill). That one fact reads
+as "changed" every run and poisons the ~4 `MonomorphicValue`s that transitively depend on it, forcing the 214 ms
+re-typecheck. It is the same defect as the 92 above, one step worse.
+
+### The fix: land Step 2 (the `UpToDate` anchor), for real this time
+
+This is exactly §6 Step 2, and the measurement now proves it fixes *both* residual bugs in one move — the earlier
+revert bundled it with the cache-size Step-1 attempt (§5), so it never landed on its own.
+
+Give every input-less contributor the `UpToDate` edge, uniformly at the top of the generation so *every* return
+path (hit, miss, and abort-guarded) is covered — the same two lines `SystemNativesProcessor` already carries:
+
+```scala
+getFactIfProduced(UpToDate.Key()) >> …the existing body…
+```
+
+- `StdlibNativesProcessor` — reads nothing on the hit path; the 92 facts are almost all its and
+  `DataTypeNativesProcessor`/`MatchNativesProcessor`'s `None`/`Leaf` contributions.
+- `DataTypeNativesProcessor`, `MatchNativesProcessor` — read facts on their *hit* path but contribute `None`
+  without reading for every name that is not theirs (most names), so the anchor must sit above the branch.
+- `UserValueNativesProcessor` / `BodyContributorProcessor` — read `SaturatedValue` on the user path, so mostly
+  have edges already; anchor anyway for uniformity and the body-less-`None` path.
+
+After the anchor, each such `ContributedBinding` becomes a non-leaf whose one edge is the always-equal `UpToDate`
+constant: `resolve` validates it structurally and **accepts it from cache** instead of regenerating, and the
+value-less one is drilled (not re-typechecked), which removes the `MonomorphicValue` cascade.
+
+**Projected result:** 366 → ~269 regenerations (92 `ContributedBinding` + the 4 `MonomorphicValue` gone), with
+`MonomorphicTypeCheckProcessor` at **0 calls** — the 214 ms, 22.7 % line disappears. The remaining ~18 value-less
+`NativeBinding`/`ContributedBinding` top-level demands are §3.1 and need Step 1 (the `FactCodec`/`OpaqueCodec`);
+several of *those* are likely only demanded because the 4 `MonomorphicValue`s currently regenerate, so re-measure
+after the anchor before sizing Step 1.
+
+**Risk & verification.** The anchor only *widens* what is accepted from cache, so the risk is under-invalidation.
+Guard it exactly as §6 Step 6 says: `./mill __.test`; the fast example sweep + byte-identical cold-vs-warm jar
+(now runnable since jar output is deterministic); a touch-one-source test confirming a bounded, correct subset
+still recompiles; and an assertion on the metric itself — a warm run over an unchanged tree regenerates only world
+leaves (no `ContributedBinding`, no `MonomorphicValue`). The `UpToDate` read stays `getFactIfProduced` (tolerant):
+a minimal test bundle without `UpToDateProcessor` loses incrementality here but never fails.
+
+Reproduction: enable `<Logger name="com.vanillasource.eliot.eliotc.compiler.IncrementalFactGenerator"
+level="debug"/>`, build twice, read the `Incremental run: regenerated N` line (the per-reason breakdown above came
+from temporary traces in `regenerate`/`computeUnchanged`, reverted — Step 5's permanent DEBUG trace would make it
+standing).

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/DataTypeNativesProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/DataTypeNativesProcessor.scala
@@ -1,6 +1,7 @@
 package com.vanillasource.eliot.eliotc.monomorphize.processor
 
 import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.compiler.cache.UpToDate
 import com.vanillasource.eliot.eliotc.module.fact.Qualifier
 import com.vanillasource.eliot.eliotc.module.fact.WellKnownTypes.{functionDataTypeFQN, typeFQN}
 import com.vanillasource.eliot.eliotc.module.fact.ValueFQN
@@ -30,7 +31,14 @@ class DataTypeNativesProcessor extends SingleFactProcessor[ContributedBinding.Ke
 
   override def generateSingleFact(key: ContributedBinding.Key): CompilerIO[ContributedBinding] =
     if (key.label =!= ContributedBinding.dataTypeLabel) abort
-    else dataTypeReduction(key.vfqn).map(red => ContributedBinding(key.vfqn, key.label, red.map(BindingContribution.Leaf(_))))
+    // A `None` contribution (every name that is not a data-type constructor — the common case) reads no fact, so
+    // without an anchor its entry has an empty dependency set and the incremental cache treats it as a source leaf,
+    // regenerating it on every no-change build. Depending on the always-clean `UpToDate` leaf (the value is immaterial,
+    // only the edge matters) makes it a drillable non-leaf the cache proves unchanged instead. Same pattern, and same
+    // deliberate tolerance (`getFactIfProduced`), as `SystemNativesProcessor`.
+    else
+      getFactIfProduced(UpToDate.Key()) >>
+        dataTypeReduction(key.vfqn).map(red => ContributedBinding(key.vfqn, key.label, red.map(BindingContribution.Leaf(_))))
 
   /** A body-less `Type`-qualified constructor's inert `VTopDef` reduction, or `None` (totality) for anything else: a
     * non-`Type` name, the system-owned `Function`/`Type`, a type alias (has a body), or a name with no resolved value.

--- a/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/MatchNativesProcessor.scala
+++ b/lang/src/com/vanillasource/eliot/eliotc/monomorphize/processor/MatchNativesProcessor.scala
@@ -2,6 +2,7 @@ package com.vanillasource.eliot.eliotc.monomorphize.processor
 
 import cats.syntax.all.*
 import com.vanillasource.eliot.eliotc.ability.util.ImplementationMarkerUtils
+import com.vanillasource.eliot.eliotc.compiler.cache.UpToDate
 import com.vanillasource.eliot.eliotc.module.fact.{
   ModuleConstructors,
   ModuleName,
@@ -39,7 +40,14 @@ class MatchNativesProcessor extends SingleFactProcessor[ContributedBinding.Key] 
 
   override def generateSingleFact(key: ContributedBinding.Key): CompilerIO[ContributedBinding] =
     if (key.label =!= ContributedBinding.matchLabel) abort
-    else matchReduction(key.vfqn).map(red => ContributedBinding(key.vfqn, key.label, red.map(BindingContribution.Leaf(_))))
+    // A `None` contribution (every name that is not a match-dispatch impl — the common case) reads no fact, so without
+    // an anchor its entry has an empty dependency set and the incremental cache treats it as a source leaf, regenerating
+    // it on every no-change build. Depending on the always-clean `UpToDate` leaf (the value is immaterial, only the edge
+    // matters) makes it a drillable non-leaf the cache proves unchanged instead. Same pattern, and same deliberate
+    // tolerance (`getFactIfProduced`), as `SystemNativesProcessor`.
+    else
+      getFactIfProduced(UpToDate.Key()) >>
+        matchReduction(key.vfqn).map(red => ContributedBinding(key.vfqn, key.label, red.map(BindingContribution.Leaf(_))))
 
   /** The match-dispatch native reduction for `vfqn`, or `None` (totality) if `vfqn` is not a `handleCases`/`typeMatch`
     * implementation method.

--- a/stdlib/src/com/vanillasource/eliot/eliotc/stdlib/plugin/StdlibNativesProcessor.scala
+++ b/stdlib/src/com/vanillasource/eliot/eliotc/stdlib/plugin/StdlibNativesProcessor.scala
@@ -2,6 +2,7 @@ package com.vanillasource.eliot.eliotc.stdlib.plugin
 
 import cats.syntax.all.*
 import com.vanillasource.eliot.eliotc.ability.util.ImplementationMarkerUtils
+import com.vanillasource.eliot.eliotc.compiler.cache.UpToDate
 import com.vanillasource.eliot.eliotc.module.fact.{ModuleName, QualifiedName, Qualifier, ValueFQN}
 import com.vanillasource.eliot.eliotc.module.fact.WellKnownTypes.{bigIntFQN, boolFQN}
 import com.vanillasource.eliot.eliotc.monomorphize.domain.SemValue
@@ -121,12 +122,18 @@ class StdlibNativesProcessor extends SingleFactProcessor[ContributedBinding.Key]
 
   override def generateSingleFact(key: ContributedBinding.Key): CompilerIO[ContributedBinding] =
     if (key.label =!= StdlibNativesProcessor.stdlibLabel) abort
+    // The hit path answers from the static `bindings` map without reading any fact, so without an anchor those
+    // contributions (`Bool.fold`, `Numeric.add`, the `String` reductions, …) have an empty dependency set and the
+    // incremental cache treats them as source leaves, regenerating them on every no-change build. Depending on the
+    // always-clean `UpToDate` leaf (the value is immaterial, only the edge matters) makes each a drillable non-leaf the
+    // cache proves unchanged instead. Same pattern, and same deliberate tolerance (`getFactIfProduced`), as
+    // `SystemNativesProcessor`; the miss path already reads ability-marker facts but the anchor covers it uniformly.
     else
-      bindings.get(key.vfqn) match {
+      getFactIfProduced(UpToDate.Key()) >> (bindings.get(key.vfqn) match {
         case some @ Some(_) => ContributedBinding(key.vfqn, key.label, some.map(BindingContribution.Leaf(_))).pure[CompilerIO]
         case None           =>
           abilityImplNativeFor(key.vfqn).map(sem => ContributedBinding(key.vfqn, key.label, sem.map(BindingContribution.Leaf(_))))
-      }
+      })
 
   /** The natives attached *directly* to an ability-implementation method rather than to a plain `Default`-qualified leaf.
     * An impl method's FQN carries a per-module `index` assigned during resolution, so it cannot be keyed statically in


### PR DESCRIPTION
Yesterday's NativeBinding/UnifiedModuleNames totalization removed the §3.3
decline-poison. Re-measured on a DischargeDemo warm build, regenerations fell
2129 -> 366 and wall time 4385 -> 944 ms, but the build is still not leaf-only.

Instrumenting regenerate() (why each fact re-ran) and computeUnchanged() (which
dependency was judged changed) pins the residual to a single root cause: the
input-less native contributors (StdlibNativesProcessor and the None/miss paths
of DataTypeNativesProcessor/MatchNativesProcessor) answer without reading any
fact, so their ContributedBindings carry no edges and are treated as world
leaves -- 92 regenerate every run, and one that is also value-less poisons the
~4 MonomorphicValue re-checks that are the dominant 214 ms cost. This is §3.2,
and the fix is §6 Step 2 (the UpToDate anchor SystemNativesProcessor already
carries), now measured to fix both residual bugs at once.

Records the per-reason breakdown, the confirmed cascade, the sharpened Step 2,
the projected 366 -> ~269 with MonomorphicTypeCheck at 0 calls, and the
under-invalidation verification it needs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01StqGTxuqTUuTHTfC4vBW2M