### PR TITLE
Add warm-build leaf-only regeneration test

### DIFF
--- a/eliotc/src/com/vanillasource/eliot/eliotc/compiler/IncrementalFactGenerator.scala
+++ b/eliotc/src/com/vanillasource/eliot/eliotc/compiler/IncrementalFactGenerator.scala
@@ -40,7 +40,7 @@ final class IncrementalFactGenerator(
     producedDuring: Ref[IO, Map[CompilerFactKey[?], CompilerFactKey[?]]],
     carriedForward: Ref[IO, Map[CompilerFactKey[?], CacheEntry]],
     unchangedChecks: Ref[IO, Map[CompilerFactKey[?], Deferred[IO, Boolean]]],
-    regeneratedCount: Ref[IO, Int]
+    regeneratedKeysRef: Ref[IO, Set[CompilerFactKey[?]]]
 ) extends CompilationProcess
     with Logging {
 
@@ -164,7 +164,7 @@ final class IncrementalFactGenerator(
     */
   private def regenerate(key: CompilerFactKey[?], ancestors: List[CompilerFactKey[?]]): IO[Unit] =
     for {
-      _          <- regeneratedCount.update(_ + 1)
+      _          <- regeneratedKeysRef.update(_ + key)
       _          <- directDependencies.update(deps => deps.updated(key, deps.getOrElse(key, Set.empty)))
       sawMissing <- Ref.of[IO, Boolean](false)
       tracking    = new DependencyTrackingProcess(this, key, directDependencies, producedDuring, errors, sawMissing, ancestors)
@@ -217,6 +217,23 @@ final class IncrementalFactGenerator(
 
   def currentErrors(): IO[Seq[CompilerError]] = errors.get.map(_.toList)
 
+  /** The keys this run regenerated (ran a processor for from scratch) rather than accepting from the prior cache. On a
+    * warm build over an unchanged tree this is exactly the set of world leaves — facts with no recorded dependencies,
+    * e.g. every `FileStat`, the `OutputFileStat` digest, and the `UpToDate` anchor constant — which are always
+    * regenerated as the boundary with the external world.
+    */
+  def regeneratedKeys(): IO[Set[CompilerFactKey[?]]] = regeneratedKeysRef.get
+
+  /** The regenerated keys that were **not** world leaves in the prior cache — facts re-run from scratch despite having
+    * recorded dependencies (or being newly seen this run). On a warm build over an unchanged tree this MUST be empty:
+    * every non-leaf fact validates structurally and is accepted from cache. A non-empty result is a warm-build
+    * regression surfacing as needless recomputation — a contributor whose input-less generation lost its `UpToDate`
+    * anchor (an edge-less entry read as a leaf), an equality-unstable fact, or a genuinely missing prior — see
+    * `docs/incremental-compilation.md` §3 and §8.
+    */
+  def nonLeafRegenerations(): IO[Set[CompilerFactKey[?]]] =
+    regeneratedKeysRef.get.map(_.filterNot(key => prior.get(key).exists(_.directDeps.isEmpty)))
+
   /** Build the cache to persist after this run. Two sources are merged:
     *
     *   - facts **materialised** this run (regenerated or accepted) — a fresh entry with their value and recorded
@@ -238,7 +255,7 @@ final class IncrementalFactGenerator(
       deps        <- directDependencies.get
       pushedBy    <- producedDuring.get
       carried     <- carriedForward.get
-      regenerated <- regeneratedCount.get
+      regenerated <- regeneratedKeysRef.get.map(_.size)
       _           <- debug[IO](s"Incremental run: regenerated $regenerated fact(s); ${factMap.size} materialised, " +
                        s"${carried.size} validated unchanged without recompute.")
     } yield {
@@ -271,7 +288,7 @@ object IncrementalFactGenerator {
       producedDuring  <- Ref.of[IO, Map[CompilerFactKey[?], CompilerFactKey[?]]](Map.empty)
       carriedForward  <- Ref.of[IO, Map[CompilerFactKey[?], CacheEntry]](Map.empty)
       unchangedChecks <- Ref.of[IO, Map[CompilerFactKey[?], Deferred[IO, Boolean]]](Map.empty)
-      regenerated     <- Ref.of[IO, Int](0)
+      regenerated     <- Ref.of[IO, Set[CompilerFactKey[?]]](Set.empty)
     } yield new IncrementalFactGenerator(
       generator,
       prior.map(_.entries).getOrElse(Map.empty),

--- a/jvm/test/src/com/vanillasource/eliot/eliotc/jvm/WarmBuildLeafOnlyTest.scala
+++ b/jvm/test/src/com/vanillasource/eliot/eliotc/jvm/WarmBuildLeafOnlyTest.scala
@@ -1,0 +1,87 @@
+package com.vanillasource.eliot.eliotc.jvm
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all.*
+import com.vanillasource.eliot.eliotc.compiler.{CompilationSession, Compiler}
+import com.vanillasource.eliot.eliotc.processor.CompilerFactKey
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+
+/** The standing warm-build metric assertion (`docs/incremental-compilation.md` §6 Step 6, §8): a warm compilation over
+  * an unchanged source tree must regenerate **only world leaves** — the facts that form the boundary with the external
+  * world and are therefore always re-run (every `FileStat`, the `OutputFileStat` digest, the `UpToDate` anchor
+  * constant, the synthetic-main `SourceContent`). Everything else — every native contributor's `ContributedBinding`,
+  * every `NativeBinding`, and above all every `MonomorphicValue` — must validate structurally and be accepted from the
+  * warm in-memory cache without re-running its processor.
+  *
+  * This is the test that would have caught the two warm-build regressions §3/§8 diagnose: an input-less contributor
+  * that loses its `UpToDate` anchor becomes an edge-less entry read as a leaf, and an equality-unstable fact reports
+  * "value differs" every run — either one drags a slice of the monomorphize layer back through a needless re-typecheck.
+  * The assertion is a single structural invariant ([[com.vanillasource.eliot.eliotc.compiler.IncrementalFactGenerator.nonLeafRegenerations]]
+  * is empty), so it guards *any* contributor that forgets the anchor, not just the three the fix addressed.
+  *
+  * Unlike the shared-session suites ([[FullIntegrationTest]]), this test drives its own [[CompilationSession]] and
+  * compiles the *same* source file **in place, untouched** between the two runs: rewriting it (as `compileAndRun` does)
+  * would move its mtime and force the non-leaf `SourceContent` to recompute-and-compare, which is not the unchanged-tree
+  * scenario §8 measures. Writing once and compiling twice reproduces that measurement exactly.
+  */
+class WarmBuildLeafOnlyTest extends AsyncFlatSpec with AsyncIOSpec with Matchers {
+
+  private val program = """def main: {Console} Unit = printLine("warm")"""
+
+  "a warm build over an unchanged tree" should "regenerate only world leaves" in {
+    withSession(program) { session =>
+      for {
+        cold     <- session.compileOnce()
+        warm     <- session.compileOnce()
+        nonLeaf  <- warm.generator.nonLeafRegenerations()
+        warmKeys <- warm.generator.regeneratedKeys()
+      } yield {
+        cold.targetProduced shouldBe true
+        warm.targetProduced shouldBe true
+        warm.errors shouldBe Seq.empty
+        // The warm run still re-runs the world leaves (never a no-op), but *nothing* with recorded dependencies.
+        warmKeys should not be empty
+        nonLeaf shouldBe Set.empty[CompilerFactKey[?]]
+      }
+    }
+  }
+
+  it should "regenerate far fewer facts warm than cold" in {
+    withSession(program) { session =>
+      for {
+        cold     <- session.compileOnce()
+        warm     <- session.compileOnce()
+        coldKeys <- cold.generator.regeneratedKeys()
+        warmKeys <- warm.generator.regeneratedKeys()
+      } yield warmKeys.size should be < coldKeys.size
+    }
+  }
+
+  /** Build a dedicated session over a fresh source/target directory pair holding `source` as module `Test`, then run
+    * `use` against it. Mirrors [[FullIntegrationTest.SharedSession]]'s argument construction (the `jvm exe-jar` command
+    * plus one `--path` per layer `eliot/` root), but hands the session out directly so the caller controls each
+    * `compileOnce` and never rewrites the source between runs.
+    */
+  private def withSession(source: String)(use: CompilationSession => IO[Assertion]): IO[Assertion] =
+    for {
+      sourceDir  <- IO.blocking(Files.createTempDirectory("eliot-warm-src"))
+      targetDir  <- IO.blocking(Files.createTempDirectory("eliot-warm-target"))
+      _          <- IO.blocking(Files.writeString(sourceDir.resolve("Test.els"), source))
+      args        = List("jvm", "exe-jar", sourceDir.toString, "-o", targetDir.toString, "-m", "Test") ++ layerPathArgs
+      sessionOpt <- Compiler.createSession(args)
+      session    <- IO.fromOption(sessionOpt)(new IllegalStateException("Could not create the compilation session."))
+      result     <- use(session)
+    } yield result
+
+  private def layerPathArgs: List[String] = {
+    val repoRoot             =
+      Path.of(Option(System.getenv("ELIOT_REPO_ROOT")).getOrElse(System.getProperty("user.dir")))
+    def root(module: String) = repoRoot.resolve(module).resolve("eliot").toString
+    List("--path", root("lang"), "--path", root("stdlib"), "--path", root("jvm"))
+  }
+}


### PR DESCRIPTION
Adds the standing metric assertion from the incremental-compilation plan
(§6 Step 6, §8): a warm compile over an unchanged tree must regenerate only
world leaves — every FileStat, the OutputFileStat digest, the UpToDate anchor,
the synthetic-main SourceContent — while every native contributor, NativeBinding
and MonomorphicValue is accepted structurally from the warm cache.

Exposes the regeneration metric on IncrementalFactGenerator: regeneratedKeys()
(the set of keys re-run this run) and nonLeafRegenerations() (those whose prior
entry had recorded dependencies, which must be empty on a warm unchanged build).
The private regeneration counter becomes a key set; the debug line is unchanged.

WarmBuildLeafOnlyTest drives its own CompilationSession and compiles the same
source in place, untouched, twice — reproducing the §8 measurement exactly
(rewriting the file would move its mtime and regenerate the non-leaf
SourceContent). It guards any contributor that forgets its UpToDate anchor,
not just the three the fix addressed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MqS6KSs35QCMWrHNpZYCkV